### PR TITLE
fix: RestartJail now reloads config into existing JailRuntimes

### DIFF
--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -289,6 +289,108 @@ func TestManagerRunRoutesEvents(t *testing.T) {
 
 	waitForContent(t, outFile, "31.24.155.180", 3*time.Second)
 }
+// writeRestartTestCfg writes a minimal jail YAML config to cfgFile.
+// The on_match action appends the literal jail_time seconds value to outFile
+// so tests can verify which config was in effect when the action ran.
+func writeRestartTestCfg(t *testing.T, cfgFile, logFile, outFile string, jailTimeSec int) {
+	t.Helper()
+	content := fmt.Sprintf(`version: 1
+engine:
+  poll_interval: 50ms
+  read_from_end: false
+jails:
+  - name: test-restart
+    enabled: true
+    files:
+      - %s
+    filters:
+      - '^(?P<ip>\S+) '
+    hit_count: 1
+    find_time: 1m
+    jail_time: %ds
+    actions:
+      on_match:
+        - 'echo %d >> %s'
+`, logFile, jailTimeSec, jailTimeSec, outFile)
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRestartJailReloadsConfig is a regression test for the bug where
+// RestartJail did not apply updated config values to existing JailRuntimes.
+// After a restart the new jail_time (and any other changed config) must be
+// used by subsequent on_match actions.
+func TestRestartJailReloadsConfig(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "access.log")
+	outFile := filepath.Join(dir, "blocked.txt")
+	cfgFile := filepath.Join(dir, "jail.yaml")
+
+	if err := os.WriteFile(logFile, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initial config: jail_time=3600s (1h).
+	writeRestartTestCfg(t, cfgFile, logFile, outFile, 3600)
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	mgr, err := NewManager(cfg, cfgFile)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	ctx := context.Background()
+	jr := mgr.jails["test-restart"]
+
+	// First trigger (IP 1.2.3.4) — must write "3600" to outFile.
+	if err := jr.HandleEvent(ctx, watch.Event{
+		JailName: "test-restart",
+		FilePath: logFile,
+		Line:     "1.2.3.4 - first hit",
+		Time:     time.Now(),
+	}); err != nil {
+		t.Fatalf("HandleEvent (before restart): %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("outFile not created after first hit: %v", err)
+	}
+	if !strings.Contains(string(data), "3600") {
+		t.Fatalf("expected '3600' in output before restart, got %q", string(data))
+	}
+
+	// Update config on disk: jail_time=14400s (4h).
+	writeRestartTestCfg(t, cfgFile, logFile, outFile, 14400)
+
+	if err := mgr.RestartJail(ctx, "test-restart"); err != nil {
+		t.Fatalf("RestartJail: %v", err)
+	}
+
+	// Second trigger: use a different IP (2.3.4.5) so the HitTracker doesn't
+	// suppress the second event.  on_match must now write "14400".
+	if err := jr.HandleEvent(ctx, watch.Event{
+		JailName: "test-restart",
+		FilePath: logFile,
+		Line:     "2.3.4.5 - second hit",
+		Time:     time.Now(),
+	}); err != nil {
+		t.Fatalf("HandleEvent (after restart): %v", err)
+	}
+
+	data, err = os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading outFile after restart: %v", err)
+	}
+	if !strings.Contains(string(data), "14400") {
+		t.Fatalf("expected '14400' in output after restart (config reload), got %q", string(data))
+	}
+}
+
 // TestApacheWordpressIntegration_ThresholdResetAfterWindow verifies that hits
 // outside the find_time window are discarded and do not contribute to the
 // threshold, using HandleEvent directly with controlled timestamps.

--- a/internal/engine/jail_runtime.go
+++ b/internal/engine/jail_runtime.go
@@ -93,13 +93,35 @@ func (jr *JailRuntime) lifecycleCtx() action.Context {
 	}
 }
 
+// Reconfigure updates the jail's config and recompiles its filters.
+// It is safe to call concurrently with HandleEvent; the hit tracker is reset
+// because find_time and hit_count may have changed.
+func (jr *JailRuntime) Reconfigure(cfg *config.JailConfig) error {
+	includes, err := filter.CompileAll(cfg.Filters)
+	if err != nil {
+		return fmt.Errorf("compiling include filters: %w", err)
+	}
+	excludes, err := filter.CompileAll(cfg.ExcludeFilters)
+	if err != nil {
+		return fmt.Errorf("compiling exclude filters: %w", err)
+	}
+	jr.mu.Lock()
+	jr.cfg = cfg
+	jr.includes = includes
+	jr.excludes = excludes
+	jr.hits = NewHitTracker()
+	jr.mu.Unlock()
+	return nil
+}
+
 // Start sets status to started and runs on_start actions.
 func (jr *JailRuntime) Start(ctx context.Context) error {
 	jr.mu.Lock()
 	jr.status = StatusStarted
+	cfg := jr.cfg
 	jr.mu.Unlock()
 
-	_, err := action.RunAll(ctx, jr.cfg.Actions.OnStart, jr.lifecycleCtx(), 0)
+	_, err := action.RunAll(ctx, cfg.Actions.OnStart, jr.lifecycleCtx(), 0)
 	return err
 }
 
@@ -107,15 +129,19 @@ func (jr *JailRuntime) Start(ctx context.Context) error {
 func (jr *JailRuntime) Stop(ctx context.Context) error {
 	jr.mu.Lock()
 	jr.status = StatusStopped
+	cfg := jr.cfg
 	jr.mu.Unlock()
 
-	_, err := action.RunAll(ctx, jr.cfg.Actions.OnStop, jr.lifecycleCtx(), 0)
+	_, err := action.RunAll(ctx, cfg.Actions.OnStop, jr.lifecycleCtx(), 0)
 	return err
 }
 
 // Restart runs on_restart actions; status remains started.
 func (jr *JailRuntime) Restart(ctx context.Context) error {
-	_, err := action.RunAll(ctx, jr.cfg.Actions.OnRestart, jr.lifecycleCtx(), 0)
+	jr.mu.RLock()
+	cfg := jr.cfg
+	jr.mu.RUnlock()
+	_, err := action.RunAll(ctx, cfg.Actions.OnRestart, jr.lifecycleCtx(), 0)
 	return err
 }
 
@@ -130,9 +156,13 @@ func (jr *JailRuntime) Status() JailStatus {
 // globs, deduplicated, capped at limit (0 = no limit). If logFiles is true
 // each match is emitted via slog at Info level.
 func (jr *JailRuntime) ConfigFiles(limit int, logFiles bool) []string {
+	jr.mu.RLock()
+	cfg := jr.cfg
+	jr.mu.RUnlock()
+
 	seen := make(map[string]bool)
 	var files []string
-	for _, pattern := range jr.cfg.Files {
+	for _, pattern := range cfg.Files {
 		paths, _ := filepath.Glob(pattern)
 		for _, p := range paths {
 			if seen[p] {
@@ -140,7 +170,7 @@ func (jr *JailRuntime) ConfigFiles(limit int, logFiles bool) []string {
 			}
 			seen[p] = true
 			if logFiles {
-				slog.Info("config files match", "jail", jr.cfg.Name, "file", p)
+				slog.Info("config files match", "jail", cfg.Name, "file", p)
 			}
 			files = append(files, p)
 			if limit > 0 && len(files) >= limit {
@@ -156,6 +186,11 @@ func (jr *JailRuntime) ConfigFiles(limit int, logFiles bool) []string {
 // number that matched, and (when returnMatching is true) up to limit matching
 // lines (0 = no limit).
 func (jr *JailRuntime) ConfigTest(filePath string, limit int, returnMatching bool) (totalLines, matchingLines int, matches []string, err error) {
+	jr.mu.RLock()
+	includes := jr.includes
+	excludes := jr.excludes
+	jr.mu.RUnlock()
+
 	f, err := os.Open(filePath)
 	if err != nil {
 		return 0, 0, nil, err
@@ -166,7 +201,7 @@ func (jr *JailRuntime) ConfigTest(filePath string, limit int, returnMatching boo
 	for scanner.Scan() {
 		line := scanner.Text()
 		totalLines++
-		result, matchErr := filter.Match(line, jr.includes, jr.excludes)
+		result, matchErr := filter.Match(line, includes, excludes)
 		if matchErr != nil {
 			continue
 		}
@@ -185,7 +220,16 @@ func (jr *JailRuntime) ConfigTest(filePath string, limit int, returnMatching boo
 
 // HandleEvent processes a watch.Event through the filter/hit pipeline.
 func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
-	result, err := filter.Match(evt.Line, jr.includes, jr.excludes)
+	// Snapshot mutable config state under the read lock so a concurrent
+	// Reconfigure cannot race with this event's processing.
+	jr.mu.RLock()
+	cfg := jr.cfg
+	includes := jr.includes
+	excludes := jr.excludes
+	hits := jr.hits
+	jr.mu.RUnlock()
+
+	result, err := filter.Match(evt.Line, includes, excludes)
 	if err != nil {
 		return fmt.Errorf("filter match: %w", err)
 	}
@@ -194,7 +238,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 		// Rate-limited debug log for non-matching lines.
 		if slog.Default().Enabled(ctx, slog.LevelDebug) && jr.debugLog.Allow() {
 			slog.DebugContext(ctx, "line considered",
-				"jail", jr.cfg.Name,
+				"jail", cfg.Name,
 				"file", evt.FilePath,
 				"line", evt.Line,
 				"matched", false,
@@ -205,18 +249,18 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 
 	// Filter matched — always log (matches are infrequent; no rate limit).
 	slog.Debug("filter matched",
-		"jail", jr.cfg.Name,
+		"jail", cfg.Name,
 		"file", evt.FilePath,
 		"line", evt.Line,
 		"ip", result.IP,
 	)
 
 	// Validate extracted address against configured net type.
-	switch jr.cfg.NetType {
+	switch cfg.NetType {
 	case "CIDR":
 		if _, _, cidrErr := net.ParseCIDR(result.IP); cidrErr != nil {
 			slog.Debug("ip validation failed",
-				"jail", jr.cfg.Name,
+				"jail", cfg.Name,
 				"ip", result.IP,
 				"net_type", "CIDR",
 				"error", cidrErr,
@@ -226,9 +270,9 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 	default: // "IP" or unset
 		if net.ParseIP(result.IP) == nil {
 			slog.Debug("ip validation failed",
-				"jail", jr.cfg.Name,
+				"jail", cfg.Name,
 				"ip", result.IP,
-				"net_type", jr.cfg.NetType,
+				"net_type", cfg.NetType,
 			)
 			return nil
 		}
@@ -239,19 +283,19 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 		t = time.Now()
 	}
 
-	findTime := jr.cfg.FindTime.Duration
+	findTime := cfg.FindTime.Duration
 	if findTime == 0 {
 		findTime = time.Minute
 	}
-	threshold := jr.cfg.HitCount
+	threshold := cfg.HitCount
 	if threshold == 0 {
 		threshold = 1
 	}
 
-	count, triggered := jr.hits.Record(result.IP, t, findTime, threshold)
+	count, triggered := hits.Record(result.IP, t, findTime, threshold)
 	if !triggered {
 		slog.Debug("hit count below threshold",
-			"jail", jr.cfg.Name,
+			"jail", cfg.Name,
 			"ip", result.IP,
 			"count", count,
 			"threshold", threshold,
@@ -260,7 +304,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 	}
 
 	slog.Info("hit threshold reached, running on_match",
-		"jail", jr.cfg.Name,
+		"jail", cfg.Name,
 		"ip", result.IP,
 		"count", count,
 		"threshold", threshold,
@@ -268,21 +312,21 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 
 	actCtx := action.Context{
 		IP:        result.IP,
-		Jail:      jr.cfg.Name,
+		Jail:      cfg.Name,
 		File:      evt.FilePath,
 		Line:      evt.Line,
-		JailTime:  int64(jr.cfg.JailTime.Duration.Seconds()),
+		JailTime:  int64(cfg.JailTime.Duration.Seconds()),
 		FindTime:  int64(findTime.Seconds()),
 		HitCount:  count,
 		Timestamp: t.UTC().Format(time.RFC3339),
 	}
 
 	// Query pre-check: exit 0 means the IP is already blocked — skip on_match.
-	if jr.cfg.Query != "" {
-		res, _ := action.Run(ctx, jr.cfg.Query, actCtx, 10*time.Second)
+	if cfg.Query != "" {
+		res, _ := action.Run(ctx, cfg.Query, actCtx, 10*time.Second)
 		if res.ExitCode == 0 && res.Error == nil {
 			slog.Info("query pre-check suppressed on_match",
-				"jail", jr.cfg.Name,
+				"jail", cfg.Name,
 				"ip", result.IP,
 				"query_exit_code", res.ExitCode,
 			)
@@ -290,6 +334,6 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 		}
 	}
 
-	_, err = action.RunAll(ctx, jr.cfg.Actions.OnMatch, actCtx, 0)
+	_, err = action.RunAll(ctx, cfg.Actions.OnMatch, actCtx, 0)
 	return err
 }

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -163,6 +163,7 @@ func (m *Manager) RestartJail(ctx context.Context, name string) error {
 	m.mu.Lock()
 
 	// Collect jails to stop (removed or disabled) and remove them from the map.
+	// For jails that remain enabled, apply the new config in-place.
 	var toStop []*JailRuntime
 	for jailName, jr := range m.jails {
 		newJailCfg, exists := newJailCfgs[jailName]
@@ -171,6 +172,13 @@ func (m *Manager) RestartJail(ctx context.Context, name string) error {
 				toStop = append(toStop, jr)
 			}
 			delete(m.jails, jailName)
+		} else {
+			// Jail still exists and is enabled — update its config now so that
+			// subsequent HandleEvent calls and on_restart actions use the new values.
+			if err := jr.Reconfigure(newJailCfg); err != nil {
+				m.mu.Unlock()
+				return fmt.Errorf("reconfiguring jail %q: %w", jailName, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Before this fix, RestartJail loaded the new config from disk but only used it for newly-discovered jails.  Pre-existing JailRuntimes kept their old JailConfig, so values like jail_time were not updated until the daemon was fully restarted.

Changes:
- Add JailRuntime.Reconfigure(cfg) — atomically replaces cfg, recompiles filters, and resets the hit tracker under jr.mu, so a concurrent HandleEvent cannot observe a partial update.
- Update HandleEvent (and ConfigFiles/ConfigTest/lifecycle methods) to snapshot config state under jr.mu.RLock() at the start of each call, making them safe against concurrent Reconfigure.
- In Manager.RestartJail, call jr.Reconfigure(newJailCfg) for each jail that remains enabled after the config reload, before running on_restart actions.
- Add regression test TestRestartJailReloadsConfig that writes a config file with jail_time=1h, triggers on_match, updates the file to jail_time=4h, calls RestartJail, and verifies the next on_match uses the new value (14400s not 3600s).