### PR TITLE
tools: retry iptocidr once on transient failure in ipset-add-cidr.sh

### DIFF
--- a/samples/tools/ipset-add-cidr.sh
+++ b/samples/tools/ipset-add-cidr.sh
@@ -26,9 +26,14 @@ if ! command -v iptocidr &>/dev/null; then
     exit 1
 fi
 
+# iptocidr may transiently fail when a concurrent invocation is writing the
+# WHOIS cache for the same IP.  Retry once after a short delay before giving up.
 CIDR=$(iptocidr "$IP" 2>/dev/null) || {
-    echo "ipset-add-cidr: iptocidr failed for IP '$IP'" >&2
-    exit 1
+    sleep 1
+    CIDR=$(iptocidr "$IP" 2>/dev/null) || {
+        echo "ipset-add-cidr: iptocidr failed for IP '$IP'" >&2
+        exit 1
+    }
 }
 
 # ── Validate output ───────────────────────────────────────────────────────────


### PR DESCRIPTION
When multiple jailtimed goroutines process events for the same IP concurrently, two iptocidr processes can race to write the WHOIS cache for a new IP.  Add a single 1-second retry so a transient cache-race failure in iptocidr does not prevent the ipset entry from being added.