### PR TITLE
config/engine: add query_before_match jail option

### DIFF
--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,45 @@
+# Code Conventions & Key Patterns
+
+## Config YAML
+- Pointer booleans (`*bool`) in `rawJailConfig`/`rawEngineConfig` to distinguish "not set" from `false`
+- Parsed `JailConfig`/`EngineConfig` use plain values after defaults are applied
+- `enabled` defaults to `true`; `read_from_end` defaults to `true`
+- Duration fields use custom `config.Duration` type (wraps `time.Duration`) for Go duration strings
+- `yaml.KnownFields(true)` — unknown YAML keys are a parse error
+
+## Filters
+- Include-filter patterns **must** contain named capture group `(?P<ip>...)` for `filter.Extract`
+- Exclude filters are plain regex (no capture group needed)
+- `filter.Match` returns `nil, nil` on no match — callers must nil-check the result
+
+## Watch Backends
+- Both `PollBackend` and `FsnotifyBackend` call `filepath.Glob` on every tick/rescan
+- `FsnotifyBackend` falls back to `PollBackend` if fsnotify creation fails
+- `WatchSpec.Globs` is a slice — a single jail can watch multiple glob patterns
+
+## Shell Actions (text/template)
+Available variables: `{{.IP}}`, `{{.Jail}}`, `{{.File}}`, `{{.Line}}`, `{{.JailTime}}` (seconds), `{{.FindTime}}` (seconds), `{{.HitCount}}`, `{{.Timestamp}}` (RFC3339)
+- `query` field: pre-check command; exit 0 → skip `on_match` (already blocked); non-zero → proceed
+
+## Control Server URL Routing
+- `/v1/health` — GET
+- `/v1/jails` — GET
+- `/v1/jails/{name}/status|start|stop|restart` — GET/POST
+- `/v1/jails/{name}/config/files` — GET (`?limit=N&log=true`)
+- `/v1/jails/{name}/config/test` — GET (`?file=/path&limit=N&matching=true`)
+- Path parsing uses `strings.SplitN(trimmed, "/", 3)` for two-level sub-actions like `config/files`
+
+## Adding a New API Endpoint (required chain)
+1. `internal/control/api.go` — add request/response structs
+2. `internal/engine/jail_runtime.go` — implement core logic on `JailRuntime`
+3. `internal/engine/manager.go` — add `Manager` method delegating to `JailRuntime` (use `m.mu.RLock`)
+4. `internal/control/server.go` — add method to `JailController` interface; add HTTP handler; wire into `handleJailAction`
+5. `internal/control/client.go` — add client method using `c.get` or `c.post`; use `url.Values` for query params
+6. `cmd/jailtimed/main.go` — add method to `JailControllerAdapter`
+7. `cmd/jailtime/main.go` — add cobra command/subcommand
+
+## Testing
+- Use `t.TempDir()` for all filesystem fixtures — no hardcoded paths
+- Watch backend tests: goroutine + `time.Sleep` + channel drain; allow 150ms for init before writing files
+- Engine tests: test `JailRuntime` directly without starting full `Manager`
+- Config fragment tests: write real YAML files to temp dirs

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,48 @@
+# jailtime — Project Overview
+
+## Purpose
+`jailtime` is a fail2ban-like daemon written in Go that watches log files for suspicious patterns and runs shell actions (e.g., blocking IPs via firewall rules) when a threshold of matching events is reached within a sliding time window.
+
+## Binaries
+- `jailtimed` — the daemon that watches log files and runs actions
+- `jailtime` — the CLI client that communicates with the daemon over HTTP-over-Unix-socket
+
+## Tech Stack
+- **Language:** Go (1.26+)
+- **Key dependencies:**
+  - `github.com/fsnotify/fsnotify` — inotify-based file watching
+  - `github.com/spf13/cobra` — CLI framework
+  - `gopkg.in/yaml.v3` — YAML config parsing
+- **Module:** `github.com/sgw/jailtime`
+
+## Architecture
+```
+jailtimed
+├── Watch Backend   — fsnotify or poll; re-expands globs each tick → Events
+├── Engine/Manager  — routes Events to JailRuntimes; handles jail lifecycle
+│   └── JailRuntime — compiled filters + HitTracker + shell action runner
+└── Control Server  — HTTP mux over Unix socket (/run/jailtime/jailtimed.sock)
+         ▲
+jailtime CLI  — control.Client (HTTP over Unix socket)
+```
+
+**Event flow:** Watch Backend emits `watch.Event{JailName, FilePath, Line}` → Manager dispatches to matching `JailRuntime.HandleEvent` → filter match → `HitTracker.Record` sliding window → if threshold hit, run `on_match` shell actions via Go `text/template`.
+
+## Directory Structure
+```
+cmd/
+  jailtime/      — CLI client binary
+  jailtimed/     — daemon binary
+internal/
+  config/        — YAML config loading, types, validation
+  control/       — HTTP API (api.go, server.go, client.go)
+  engine/        — JailRuntime, Manager, HitTracker
+  action/        — shell action runner and template rendering
+  watch/         — file watching backends (poll, fsnotify)
+  filter/        — regex filter compilation and matching
+  logging/       — logger
+pkg/             — (shared packages if any)
+samples/         — example config files
+deploy/          — deployment files
+docs/            — documentation
+```

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,28 @@
+# Suggested Commands
+
+## Build
+```sh
+go build ./cmd/jailtimed
+go build ./cmd/jailtime
+```
+
+## Test
+```sh
+# Run all tests
+go test ./...
+
+# Run tests in a specific package with verbose output
+go test -v ./internal/control/...
+
+# Run a single test
+go test ./internal/engine/... -run TestJailRuntimeConfigTest
+go test ./internal/watch/...  -run TestPollBackendSubdirGlob
+```
+
+No Makefile — all build/test is via `go` toolchain directly.
+
+## No separate lint/format step configured; use standard Go tools:
+```sh
+go vet ./...
+gofmt -l .
+```

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,6 +118,41 @@ func TestLoadInvalidNetType(t *testing.T) {
 	}
 }
 
+func TestLoadQueryBeforeMatchDefault(t *testing.T) {
+	path := writeTemp(t, minimalValidYAML)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if c.Jails[0].QueryBeforeMatch {
+		t.Error("QueryBeforeMatch should default to false when not set")
+	}
+}
+
+func TestLoadQueryBeforeMatchTrue(t *testing.T) {
+	y := minimalValidYAML + "    query: /usr/local/bin/ipset-test-cidr.sh mySet\n    query_before_match: true\n"
+	path := writeTemp(t, y)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if !c.Jails[0].QueryBeforeMatch {
+		t.Error("QueryBeforeMatch should be true when set to true in YAML")
+	}
+}
+
+func TestLoadQueryBeforeMatchFalseExplicit(t *testing.T) {
+	y := minimalValidYAML + "    query: /usr/local/bin/ipset-test-cidr.sh mySet\n    query_before_match: false\n"
+	path := writeTemp(t, y)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if c.Jails[0].QueryBeforeMatch {
+		t.Error("QueryBeforeMatch should be false when explicitly set to false in YAML")
+	}
+}
+
 const jailFragmentYAML = `
 jails:
   - name: nginx

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -18,17 +18,18 @@ type rawEngineConfig struct {
 
 // rawJailConfig mirrors JailConfig with pointer booleans to detect unset fields.
 type rawJailConfig struct {
-	Name           string      `yaml:"name"`
-	Enabled        *bool       `yaml:"enabled"`
-	Files          []string    `yaml:"files"`
-	Filters        []string    `yaml:"filters"`
-	ExcludeFilters []string    `yaml:"exclude_filters"`
-	Actions        JailActions `yaml:"actions"`
-	HitCount       int         `yaml:"hit_count"`
-	FindTime       Duration    `yaml:"find_time"`
-	JailTime       Duration    `yaml:"jail_time"`
-	NetType        string      `yaml:"net_type"`
-	Query          string      `yaml:"query"`
+	Name             string      `yaml:"name"`
+	Enabled          *bool       `yaml:"enabled"`
+	Files            []string    `yaml:"files"`
+	Filters          []string    `yaml:"filters"`
+	ExcludeFilters   []string    `yaml:"exclude_filters"`
+	Actions          JailActions `yaml:"actions"`
+	HitCount         int         `yaml:"hit_count"`
+	FindTime         Duration    `yaml:"find_time"`
+	JailTime         Duration    `yaml:"jail_time"`
+	NetType          string      `yaml:"net_type"`
+	Query            string      `yaml:"query"`
+	QueryBeforeMatch *bool       `yaml:"query_before_match"`
 }
 
 // rawConfig mirrors Config but uses raw sub-types to allow default detection.
@@ -112,6 +113,10 @@ func Load(path string) (*Config, error) {
 		} else {
 			jc.Enabled = *rj.Enabled
 		}
+		if rj.QueryBeforeMatch != nil {
+			jc.QueryBeforeMatch = *rj.QueryBeforeMatch
+		}
+		// QueryBeforeMatch defaults to false when unset (zero value).
 		c.Jails = append(c.Jails, jc)
 	}
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -53,6 +53,11 @@ type JailConfig struct {
 	// NetType is "IP" or "CIDR".
 	NetType string `yaml:"net_type"`
 	Query   string `yaml:"query"`
+	// QueryBeforeMatch controls whether the query pre-check is run before
+	// on_match actions.  When false (the default), the query is never run and
+	// on_match is always executed on a threshold hit.  When true, the query is
+	// run first; an exit code of 0 suppresses on_match (IP already handled).
+	QueryBeforeMatch bool `yaml:"query_before_match"`
 }
 
 // JailActions holds the shell command templates run at various lifecycle points.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -381,8 +381,8 @@ t.Fatalf("HandleEvent: %v", err)
 }
 }
 
-// TestHandleEventQuerySuppresses verifies that when the query pre-check returns
-// exit 0 (IP already blocked), on_match is NOT executed.
+// TestHandleEventQuerySuppresses verifies that when query_before_match is true
+// and the query pre-check returns exit 0 (IP already blocked), on_match is NOT executed.
 func TestHandleEventQuerySuppresses(t *testing.T) {
 dir := t.TempDir()
 outFile := filepath.Join(dir, "output.txt")
@@ -394,7 +394,8 @@ Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
 HitCount: 1,
 FindTime: config.Duration{Duration: time.Minute},
 // "true" always exits 0 → IP already blocked → skip on_match.
-Query: "true",
+Query:            "true",
+QueryBeforeMatch: true,
 Actions: config.JailActions{
 OnMatch: []string{"echo {{ .IP }} > " + outFile},
 },
@@ -422,8 +423,8 @@ t.Fatal("on_match should have been suppressed by query exit 0, but output file e
 }
 }
 
-// TestHandleEventQueryPermits verifies that when the query pre-check returns
-// non-zero (IP not yet blocked), on_match IS executed.
+// TestHandleEventQueryPermits verifies that when query_before_match is true
+// and the query pre-check returns non-zero (IP not yet blocked), on_match IS executed.
 func TestHandleEventQueryPermits(t *testing.T) {
 dir := t.TempDir()
 outFile := filepath.Join(dir, "output.txt")
@@ -435,7 +436,8 @@ Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
 HitCount: 1,
 FindTime: config.Duration{Duration: time.Minute},
 // "false" exits 1 → IP not yet blocked → proceed with on_match.
-Query: "false",
+Query:            "false",
+QueryBeforeMatch: true,
 Actions: config.JailActions{
 OnMatch: []string{"echo {{ .IP }} > " + outFile},
 },
@@ -464,6 +466,55 @@ t.Fatalf("on_match should have fired (query exited 1) but output file was not cr
 }
 if got := strings.TrimSpace(string(data)); got != "2.3.4.5" {
 t.Fatalf("expected output %q, got %q", "2.3.4.5", got)
+}
+}
+
+
+// TestHandleEventQueryNotRunWhenDisabled verifies that when query_before_match is
+// false (the default), the query is never run — even if a query command is set —
+// and on_match fires unconditionally on a threshold hit.
+func TestHandleEventQueryNotRunWhenDisabled(t *testing.T) {
+dir := t.TempDir()
+outFile := filepath.Join(dir, "output.txt")
+
+cfg := &config.JailConfig{
+Name:     "query-disabled-jail",
+Enabled:  true,
+Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
+HitCount: 1,
+FindTime: config.Duration{Duration: time.Minute},
+// "true" exits 0, which would suppress on_match — but QueryBeforeMatch is
+// false (default) so the query must not be run at all.
+Query:            "true",
+QueryBeforeMatch: false,
+Actions: config.JailActions{
+OnMatch: []string{"echo {{ .IP }} > " + outFile},
+},
+}
+
+jr, err := NewJailRuntime(cfg)
+if err != nil {
+t.Fatalf("NewJailRuntime: %v", err)
+}
+
+evt := watch.Event{
+JailName: "query-disabled-jail",
+FilePath: "/var/log/auth.log",
+Line:     "Failed password from 3.4.5.6",
+Time:     time.Now(),
+}
+
+ctx := context.Background()
+if err := jr.HandleEvent(ctx, evt); err != nil {
+t.Fatalf("HandleEvent: %v", err)
+}
+
+data, err := os.ReadFile(outFile)
+if err != nil {
+t.Fatalf("on_match should have fired (query_before_match=false) but output file was not created: %v", err)
+}
+if got := strings.TrimSpace(string(data)); got != "3.4.5.6" {
+t.Fatalf("expected output %q, got %q", "3.4.5.6", got)
 }
 }
 

--- a/internal/engine/jail_runtime.go
+++ b/internal/engine/jail_runtime.go
@@ -321,8 +321,9 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 		Timestamp: t.UTC().Format(time.RFC3339),
 	}
 
-	// Query pre-check: exit 0 means the IP is already blocked — skip on_match.
-	if cfg.Query != "" {
+	// Query pre-check: only run when query_before_match is true.
+	// Exit 0 means the IP is already blocked — skip on_match.
+	if cfg.QueryBeforeMatch && cfg.Query != "" {
 		res, _ := action.Run(ctx, cfg.Query, actCtx, 10*time.Second)
 		if res.ExitCode == 0 && res.Error == nil {
 			slog.Info("query pre-check suppressed on_match",


### PR DESCRIPTION
Add a new boolean field `query_before_match` to JailConfig (default: false).

Previously, any jail with a `query` command set would always run that pre-check before on_match, giving users no way to configure a query without it automatically gating the action.

With this change, the query pre-check is only run when `query_before_match: true` is explicitly set.  When false (the default), the query field is ignored and on_match fires unconditionally on a threshold hit — preserving backward-compatible behaviour for jails that have no query set.

Changes:
- internal/config/types.go: add QueryBeforeMatch bool to JailConfig
- internal/config/load.go: add QueryBeforeMatch *bool to rawJailConfig; copy to JailConfig on load (defaults to false / zero value)
- internal/engine/jail_runtime.go: gate query execution on cfg.QueryBeforeMatch
- internal/config/config_test.go: tests for default false, explicit true/false
- internal/engine/engine_test.go: update existing query tests to set QueryBeforeMatch: true; add TestHandleEventQueryNotRunWhenDisabled