### PR TITLE
config/engine/action: add action_timeout per-jail config field

### DIFF
--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -61,6 +61,17 @@ func TestRunTimeout(t *testing.T) {
 	}
 }
 
+func TestRunZeroTimeoutNoDeadline(t *testing.T) {
+	// timeout=0 means no extra deadline; a short-lived command must complete normally.
+	result, err := Run(context.Background(), "sleep 0.1", Context{}, 0)
+	if err != nil {
+		t.Fatalf("expected no error with timeout=0, got: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", result.ExitCode)
+	}
+}
+
 func TestRunAllStopsOnFailure(t *testing.T) {
 	templates := []string{"echo ok", "false", "echo never"}
 	results, err := RunAll(context.Background(), templates, Context{}, 0)

--- a/internal/action/runner.go
+++ b/internal/action/runner.go
@@ -37,20 +37,26 @@ func RunAll(ctx context.Context, templates []string, actCtx Context, timeout tim
 }
 
 // Run renders and executes a single command template.
+// A timeout of 0 means no additional per-command timeout is applied; the
+// command runs until it exits naturally or the parent context is cancelled.
+// A positive timeout adds a per-command deadline on top of any parent deadline.
+// For on_match actions, callers should pass cfg.ActionTimeout so that slow
+// scripts (e.g. those that perform a remote WHOIS lookup) are not killed
+// prematurely.
 func Run(ctx context.Context, tmpl string, actCtx Context, timeout time.Duration) (Result, error) {
-	if timeout == 0 {
-		timeout = defaultTimeout
-	}
-
 	rendered, err := Render(tmpl, actCtx)
 	if err != nil {
 		return Result{Command: tmpl, Error: err}, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	cmdCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		cmdCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", rendered)
+	cmd := exec.CommandContext(cmdCtx, "/bin/sh", "-c", rendered)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -153,6 +153,29 @@ func TestLoadQueryBeforeMatchFalseExplicit(t *testing.T) {
 	}
 }
 
+func TestLoadActionTimeoutDefault(t *testing.T) {
+	path := writeTemp(t, minimalValidYAML)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if c.Jails[0].ActionTimeout.Duration != 60*time.Second {
+		t.Errorf("ActionTimeout default = %v, want 60s", c.Jails[0].ActionTimeout.Duration)
+	}
+}
+
+func TestLoadActionTimeoutExplicit(t *testing.T) {
+	y := minimalValidYAML + "    action_timeout: 2m\n"
+	path := writeTemp(t, y)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if c.Jails[0].ActionTimeout.Duration != 2*time.Minute {
+		t.Errorf("ActionTimeout = %v, want 2m", c.Jails[0].ActionTimeout.Duration)
+	}
+}
+
 const jailFragmentYAML = `
 jails:
   - name: nginx

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -30,6 +30,7 @@ type rawJailConfig struct {
 	NetType          string      `yaml:"net_type"`
 	Query            string      `yaml:"query"`
 	QueryBeforeMatch *bool       `yaml:"query_before_match"`
+	ActionTimeout    Duration    `yaml:"action_timeout"`
 }
 
 // rawConfig mirrors Config but uses raw sub-types to allow default detection.
@@ -107,6 +108,7 @@ func Load(path string) (*Config, error) {
 			JailTime:       rj.JailTime,
 			NetType:        rj.NetType,
 			Query:          rj.Query,
+			ActionTimeout:  rj.ActionTimeout,
 		}
 		if rj.Enabled == nil {
 			jc.Enabled = true
@@ -161,6 +163,9 @@ func applyDefaults(c *Config, readFromEnd *bool) {
 	for i := range c.Jails {
 		if c.Jails[i].NetType == "" {
 			c.Jails[i].NetType = "IP"
+		}
+		if c.Jails[i].ActionTimeout.Duration == 0 {
+			c.Jails[i].ActionTimeout.Duration = defaultActionTimeout
 		}
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -58,6 +58,12 @@ type JailConfig struct {
 	// on_match is always executed on a threshold hit.  When true, the query is
 	// run first; an exit code of 0 suppresses on_match (IP already handled).
 	QueryBeforeMatch bool `yaml:"query_before_match"`
+	// ActionTimeout is the maximum time allowed for each on_match action command
+	// to complete.  Defaults to 60s.  Scripts that perform remote lookups (e.g.
+	// WHOIS) may need more than the old implicit 10-second cap.
+	// Set to 0 to disable per-command timeouts (commands block until they exit
+	// or the daemon shuts down).
+	ActionTimeout Duration `yaml:"action_timeout"`
 }
 
 // JailActions holds the shell command templates run at various lifecycle points.
@@ -84,3 +90,7 @@ const defaultSocketPath = "/run/jailtime/jailtimed.sock"
 
 // defaultPollInterval is the default engine poll interval.
 const defaultPollInterval = 2 * time.Second
+
+// defaultActionTimeout is the default per-command timeout for on_match actions.
+// 60 seconds gives scripts that perform remote WHOIS lookups time to complete.
+const defaultActionTimeout = 60 * time.Second

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -557,3 +557,83 @@ if _, err := os.Stat(outFile); err == nil {
 t.Fatal("on_match should not have fired for invalid IP, but output file exists")
 }
 }
+
+// TestHandleEventActionTimeout verifies that on_match actions respect the
+// ActionTimeout config — a command that runs within the timeout completes
+// successfully, and one that exceeds it is killed and returns an error.
+func TestHandleEventActionTimeout(t *testing.T) {
+dir := t.TempDir()
+outFile := filepath.Join(dir, "output.txt")
+
+// Action sleeps briefly then writes the IP; ActionTimeout is generous enough.
+cfg := &config.JailConfig{
+Name:          "timeout-jail",
+Enabled:       true,
+Filters:       []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
+HitCount:      1,
+FindTime:      config.Duration{Duration: time.Minute},
+ActionTimeout: config.Duration{Duration: 5 * time.Second},
+Actions: config.JailActions{
+OnMatch: []string{"sleep 0.1 && echo {{ .IP }} > " + outFile},
+},
+}
+
+jr, err := NewJailRuntime(cfg)
+if err != nil {
+t.Fatalf("NewJailRuntime: %v", err)
+}
+
+evt := watch.Event{
+JailName: "timeout-jail",
+FilePath: "/var/log/auth.log",
+Line:     "Failed password from 5.6.7.8",
+Time:     time.Now(),
+}
+
+ctx := context.Background()
+if err := jr.HandleEvent(ctx, evt); err != nil {
+t.Fatalf("HandleEvent: %v", err)
+}
+
+data, err := os.ReadFile(outFile)
+if err != nil {
+t.Fatalf("on_match should have completed within ActionTimeout but output file missing: %v", err)
+}
+if got := strings.TrimSpace(string(data)); got != "5.6.7.8" {
+t.Fatalf("expected output %q, got %q", "5.6.7.8", got)
+}
+}
+
+// TestHandleEventActionTimeoutKills verifies that an on_match action that
+// exceeds ActionTimeout is killed and HandleEvent returns an error.
+func TestHandleEventActionTimeoutKills(t *testing.T) {
+cfg := &config.JailConfig{
+Name:          "timeout-kill-jail",
+Enabled:       true,
+Filters:       []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
+HitCount:      1,
+FindTime:      config.Duration{Duration: time.Minute},
+ActionTimeout: config.Duration{Duration: 100 * time.Millisecond},
+Actions: config.JailActions{
+OnMatch: []string{"sleep 10"},
+},
+}
+
+jr, err := NewJailRuntime(cfg)
+if err != nil {
+t.Fatalf("NewJailRuntime: %v", err)
+}
+
+evt := watch.Event{
+JailName: "timeout-kill-jail",
+FilePath: "/var/log/auth.log",
+Line:     "Failed password from 9.8.7.6",
+Time:     time.Now(),
+}
+
+ctx := context.Background()
+if err := jr.HandleEvent(ctx, evt); err == nil {
+t.Fatal("expected error when on_match action exceeds ActionTimeout, got nil")
+}
+}
+

--- a/internal/engine/jail_runtime.go
+++ b/internal/engine/jail_runtime.go
@@ -25,6 +25,10 @@ const (
 	StatusStopped JailStatus = "stopped"
 )
 
+// lifecycleTimeout is the per-command timeout for on_start, on_stop, and
+// on_restart actions.  These are expected to be fast administrative commands.
+const lifecycleTimeout = 10 * time.Second
+
 // debugRateLimiter allows at most maxPerSec log entries per second.
 type debugRateLimiter struct {
 	mu          sync.Mutex
@@ -121,7 +125,7 @@ func (jr *JailRuntime) Start(ctx context.Context) error {
 	cfg := jr.cfg
 	jr.mu.Unlock()
 
-	_, err := action.RunAll(ctx, cfg.Actions.OnStart, jr.lifecycleCtx(), 0)
+	_, err := action.RunAll(ctx, cfg.Actions.OnStart, jr.lifecycleCtx(), lifecycleTimeout)
 	return err
 }
 
@@ -132,7 +136,7 @@ func (jr *JailRuntime) Stop(ctx context.Context) error {
 	cfg := jr.cfg
 	jr.mu.Unlock()
 
-	_, err := action.RunAll(ctx, cfg.Actions.OnStop, jr.lifecycleCtx(), 0)
+	_, err := action.RunAll(ctx, cfg.Actions.OnStop, jr.lifecycleCtx(), lifecycleTimeout)
 	return err
 }
 
@@ -141,7 +145,7 @@ func (jr *JailRuntime) Restart(ctx context.Context) error {
 	jr.mu.RLock()
 	cfg := jr.cfg
 	jr.mu.RUnlock()
-	_, err := action.RunAll(ctx, cfg.Actions.OnRestart, jr.lifecycleCtx(), 0)
+	_, err := action.RunAll(ctx, cfg.Actions.OnRestart, jr.lifecycleCtx(), lifecycleTimeout)
 	return err
 }
 
@@ -335,6 +339,6 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 		}
 	}
 
-	_, err = action.RunAll(ctx, cfg.Actions.OnMatch, actCtx, 0)
+	_, err = action.RunAll(ctx, cfg.Actions.OnMatch, actCtx, cfg.ActionTimeout.Duration)
 	return err
 }


### PR DESCRIPTION
Context: ipset-add-cidr.sh (via iptocidr/cipwhois) performs a remote WHOIS lookup for uncached IPs, which can legitimately take several seconds. The primary fast-failure bug (cipwhois queue.empty() race) is fixed separately in fix/iptocidr-tools on server-utils. This change adds a configurable per-command timeout for on_match actions so that genuinely slow WHOIS lookups (>10s) are not prematurely cut short.

Previously, all on_match shell actions were subject to a hard-coded 10s timeout (the defaultTimeout fallback in action.Run). Scripts like ipset-add-cidr.sh can legitimately run longer when WHOIS data is uncached and the RDAP server is slow.

Changes:

action/runner.go
  - Change timeout=0 semantics: 0 now means no extra deadline — block until the command exits or the parent context is cancelled. Callers that want a bounded timeout must pass a positive duration explicitly.

config/types.go
  - Add ActionTimeout Duration field to JailConfig (YAML: action_timeout).
  - Document that 0 means no per-command deadline.
  - Add defaultActionTimeout = 60s constant.

config/load.go
  - Add ActionTimeout Duration to rawJailConfig for YAML parsing.
  - Copy ActionTimeout to JailConfig during load.
  - Apply 60s default in applyDefaults when the field is unset.

engine/jail_runtime.go
  - Pass cfg.ActionTimeout.Duration to action.RunAll for on_match so the configured (or default 60s) deadline is used.
  - Introduce lifecycleTimeout = 10s constant for on_start/on_stop/ on_restart, which are expected to be fast administrative commands.

Tests:
  - action: TestRunZeroTimeoutNoDeadline verifies timeout=0 lets a short command complete without being terminated.
  - config: TestLoadActionTimeoutDefault (60s), TestLoadActionTimeoutExplicit (2m).
  - engine: TestHandleEventActionTimeout verifies a slow action completes within a generous ActionTimeout; TestHandleEventActionTimeoutKills verifies an action exceeding ActionTimeout is terminated and HandleEvent returns an error.