### PR TITLE
engine: skip duplicate on_match when one is already in flight per IP

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -557,3 +557,119 @@ if _, err := os.Stat(outFile); err == nil {
 t.Fatal("on_match should not have fired for invalid IP, but output file exists")
 }
 }
+
+// TestHandleEventInflightSkip verifies that a concurrent second threshold trigger
+// for the same IP is skipped while the first on_match action is still running.
+func TestHandleEventInflightSkip(t *testing.T) {
+dir := t.TempDir()
+countFile := filepath.Join(dir, "count.txt")
+
+// Action sleeps briefly to simulate a slow command (e.g. WHOIS lookup),
+// then appends a line to countFile so we can count executions.
+cfg := &config.JailConfig{
+Name:     "inflight-jail",
+Enabled:  true,
+Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
+HitCount: 1,
+FindTime: config.Duration{Duration: time.Minute},
+Actions: config.JailActions{
+OnMatch: []string{"sleep 0.2 && echo hit >> " + countFile},
+},
+}
+
+jr, err := NewJailRuntime(cfg)
+if err != nil {
+t.Fatalf("NewJailRuntime: %v", err)
+}
+
+evt := watch.Event{
+JailName: "inflight-jail",
+FilePath: "/var/log/auth.log",
+Line:     "Failed password from 7.7.7.7",
+Time:     time.Now(),
+}
+
+ctx := context.Background()
+
+// Fire three concurrent HandleEvent calls for the same IP.  Each one
+// re-records the hit (HitCount=1 threshold, so each triggers on_match),
+// but only the first should actually run the action.
+errs := make(chan error, 3)
+for i := 0; i < 3; i++ {
+go func() {
+errs <- jr.HandleEvent(ctx, evt)
+}()
+}
+for i := 0; i < 3; i++ {
+if err := <-errs; err != nil {
+t.Errorf("HandleEvent[%d] unexpected error: %v", i, err)
+}
+}
+
+// Wait for the in-flight action to finish.
+time.Sleep(400 * time.Millisecond)
+
+data, err := os.ReadFile(countFile)
+if err != nil {
+t.Fatalf("countFile not created — no on_match ran: %v", err)
+}
+lines := strings.Count(strings.TrimSpace(string(data)), "hit")
+if lines != 1 {
+t.Fatalf("expected exactly 1 on_match execution, got %d (countFile: %q)", lines, string(data))
+}
+}
+
+// TestHandleEventInflightDifferentIPs verifies that concurrent on_match actions
+// for different IPs are NOT blocked by each other.
+func TestHandleEventInflightDifferentIPs(t *testing.T) {
+dir := t.TempDir()
+
+cfg := &config.JailConfig{
+Name:     "inflight-multi-jail",
+Enabled:  true,
+Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
+HitCount: 1,
+FindTime: config.Duration{Duration: time.Minute},
+Actions: config.JailActions{
+OnMatch: []string{"sleep 0.1 && echo {{ .IP }} >> " + filepath.Join(dir, "out.txt")},
+},
+}
+
+jr, err := NewJailRuntime(cfg)
+if err != nil {
+t.Fatalf("NewJailRuntime: %v", err)
+}
+
+ctx := context.Background()
+ips := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}
+errs := make(chan error, len(ips))
+for _, ip := range ips {
+ip := ip
+go func() {
+errs <- jr.HandleEvent(ctx, watch.Event{
+JailName: "inflight-multi-jail",
+FilePath: "/var/log/auth.log",
+Line:     "Failed password from " + ip,
+Time:     time.Now(),
+})
+}()
+}
+for i := 0; i < len(ips); i++ {
+if err := <-errs; err != nil {
+t.Errorf("HandleEvent error: %v", err)
+}
+}
+
+time.Sleep(300 * time.Millisecond)
+
+data, err := os.ReadFile(filepath.Join(dir, "out.txt"))
+if err != nil {
+t.Fatalf("output file not created: %v", err)
+}
+got := strings.TrimSpace(string(data))
+for _, ip := range ips {
+if !strings.Contains(got, ip) {
+t.Errorf("expected IP %s in output, but it was missing:\n%s", ip, got)
+}
+}
+}

--- a/internal/engine/jail_runtime.go
+++ b/internal/engine/jail_runtime.go
@@ -65,6 +65,10 @@ type JailRuntime struct {
 	mu       sync.RWMutex
 	status   JailStatus
 	debugLog *debugRateLimiter
+	// inflight tracks IPs that currently have an on_match action running.
+	// Only one on_match execution per IP is allowed at a time; concurrent
+	// threshold triggers for an in-flight IP are silently skipped.
+	inflight sync.Map
 }
 
 func NewJailRuntime(cfg *config.JailConfig) (*JailRuntime, error) {
@@ -309,6 +313,19 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 		"count", count,
 		"threshold", threshold,
 	)
+
+	// Ensure at most one on_match action runs per IP at a time.
+	// If a previous trigger for the same IP is still executing its actions,
+	// skip this one — the IP will re-trigger once the in-flight action
+	// completes and the hit window fills again.
+	if _, alreadyInFlight := jr.inflight.LoadOrStore(result.IP, struct{}{}); alreadyInFlight {
+		slog.Info("on_match already in flight for ip, skipping duplicate trigger",
+			"jail", cfg.Name,
+			"ip", result.IP,
+		)
+		return nil
+	}
+	defer jr.inflight.Delete(result.IP)
 
 	actCtx := action.Context{
 		IP:        result.IP,


### PR DESCRIPTION
When a flooding IP triggers the hit threshold repeatedly in quick succession (the HitTracker resets to 0 after each trigger, so a fast attacker can re-arm it within a second), the manager dispatches each threshold event as a separate goroutine.  This meant multiple concurrent on_match shells ran for the same IP, which:

  - caused concurrent writes to the cipwhois WHOIS cache (the race condition fixed in fix/iptocidr-tools)
  - wasted resources running redundant ipset/iptables commands
  - produced the stream of repeated failures seen in production logs

Fix: add an 'inflight sync.Map' to JailRuntime.  Before executing on_match for a given IP, HandleEvent attempts to register the IP via LoadOrStore.  If another goroutine is already running on_match for that IP the new trigger is logged and dropped; the IP will re-arm and trigger again naturally once the in-flight action completes.  Different IPs are never blocked by each other.

The in-flight slot is released via defer so it is always cleared even if the action returns an error.

Tests added:
  - TestHandleEventInflightSkip: three concurrent triggers for the same IP — only one on_match executes (verified by counting file appends)
  - TestHandleEventInflightDifferentIPs: concurrent triggers for three distinct IPs — all three on_match actions run concurrently