### PR TITLE
perf: deduplicate file reads when multiple jails watch the same file

### DIFF
--- a/internal/watch/fsnotify.go
+++ b/internal/watch/fsnotify.go
@@ -40,6 +40,8 @@ func (b *FsnotifyBackend) getSpecs() []WatchSpec {
 
 // Start watches files using fsnotify for WRITE/CREATE events.
 // Periodically rescans globs to pick up new matching files.
+// One FileTailer is maintained per unique file path (shared across jails);
+// each line is fanned out to every jail whose globs match that path.
 // On CREATE event for a watched path, the FileTailer is reopened.
 func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, out chan<- Event) error {
 	b.UpdateSpecs(specs)
@@ -54,45 +56,59 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, out chan
 	defer watcher.Close()
 	slog.Info("fsnotify backend started")
 
-	type tailerKey struct {
-		jailName string
-		path     string
-	}
-	tailers := make(map[tailerKey]*FileTailer)
-	// pathToKeys maps a watched path to the set of tailerKeys using it.
-	pathToKeys := make(map[string][]tailerKey)
-
-	addFile := func(spec WatchSpec, p string) {
-		k := tailerKey{spec.JailName, p}
-		if _, ok := tailers[k]; ok {
-			return
-		}
-		ft, err := NewFileTailer(p, spec.ReadFromEnd)
-		if err != nil {
-			return
-		}
-		tailers[k] = ft
-		pathToKeys[p] = append(pathToKeys[p], k)
-		// Ignore error if already watched.
-		_ = watcher.Add(p)
-	}
+	// tailers maps file path → FileTailer (one per unique path across all jails).
+	tailers := make(map[string]*FileTailer)
+	// pathToJails maps file path → list of jail names watching it.
+	pathToJails := make(map[string][]string)
 
 	rescan := func() {
-		for _, spec := range b.getSpecs() {
+		currentSpecs := b.getSpecs()
+
+		// Rebuild pathToJails from current specs to handle jail additions/removals.
+		newPathToJails := make(map[string][]string)
+		pathReadFromEnd := make(map[string]bool)
+		for _, spec := range currentSpecs {
 			for _, pattern := range spec.Globs {
 				paths, err := filepath.Glob(pattern)
 				if err != nil {
 					continue
 				}
 				for _, p := range paths {
-					addFile(spec, p)
+					newPathToJails[p] = append(newPathToJails[p], spec.JailName)
+					if _, set := pathReadFromEnd[p]; !set {
+						pathReadFromEnd[p] = spec.ReadFromEnd
+					}
 				}
 			}
 		}
+
+		// Open tailers for newly matched paths.
+		for p := range newPathToJails {
+			if _, ok := tailers[p]; !ok {
+				ft, err := NewFileTailer(p, pathReadFromEnd[p])
+				if err != nil {
+					continue
+				}
+				tailers[p] = ft
+				// Ignore error if already watched.
+				_ = watcher.Add(p)
+			}
+		}
+
+		// Close tailers for paths no longer matched by any spec.
+		for p, ft := range tailers {
+			if _, ok := newPathToJails[p]; !ok {
+				ft.Close()
+				delete(tailers, p)
+				_ = watcher.Remove(p)
+			}
+		}
+
+		pathToJails = newPathToJails
 	}
 
-	readAndSend := func(k tailerKey) {
-		ft, ok := tailers[k]
+	readAndSend := func(p string) {
+		ft, ok := tailers[p]
 		if !ok {
 			return
 		}
@@ -101,22 +117,24 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, out chan
 			return
 		}
 		for _, line := range lines {
-			if slog.Default().Enabled(ctx, slog.LevelDebug) && ft.debugLog.Allow() {
-				slog.DebugContext(ctx, "line notified",
-					"jail", k.jailName,
-					"file", k.path,
-					"line", line,
-				)
-			}
-			select {
-			case out <- Event{
-				JailName: k.jailName,
-				FilePath: k.path,
-				Offset:   ft.offset,
-				Line:     line,
-				Time:     time.Now(),
-			}:
-			case <-ctx.Done():
+			for _, jailName := range pathToJails[p] {
+				if slog.Default().Enabled(ctx, slog.LevelDebug) && ft.debugLog.Allow() {
+					slog.DebugContext(ctx, "line notified",
+						"jail", jailName,
+						"file", p,
+						"line", line,
+					)
+				}
+				select {
+				case out <- Event{
+					JailName: jailName,
+					FilePath: p,
+					Offset:   ft.offset,
+					Line:     line,
+					Time:     time.Now(),
+				}:
+				case <-ctx.Done():
+				}
 			}
 		}
 	}
@@ -142,22 +160,20 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, out chan
 			if !ok {
 				return nil
 			}
-			keys := pathToKeys[event.Name]
-			for _, k := range keys {
-				if event.Has(fsnotify.Create) {
-					// File was recreated (rotation): reopen tailer from start.
-					if ft, ok := tailers[k]; ok {
-						ft.Close()
-					}
-					ft, err := NewFileTailer(k.path, false)
-					if err != nil {
-						delete(tailers, k)
-						continue
-					}
-					tailers[k] = ft
+			p := event.Name
+			if event.Has(fsnotify.Create) {
+				// File was recreated (rotation): reopen tailer from start.
+				if ft, ok := tailers[p]; ok {
+					ft.Close()
 				}
-				readAndSend(k)
+				ft, err := NewFileTailer(p, false)
+				if err != nil {
+					delete(tailers, p)
+					continue
+				}
+				tailers[p] = ft
 			}
+			readAndSend(p)
 
 		case _, ok := <-watcher.Errors:
 			if !ok {

--- a/internal/watch/poll.go
+++ b/internal/watch/poll.go
@@ -35,16 +35,19 @@ func (b *PollBackend) getSpecs() []WatchSpec {
 	return b.specs
 }
 
-// Start begins polling. For each WatchSpec it expands globs every interval,
-// maintains a FileTailer per matched file, and sends new lines as Events.
+// Start begins polling. Every interval it expands globs across all WatchSpecs,
+// maintains one FileTailer per unique file path (shared across jails), reads
+// each file once, and fans out new lines as Events to every jail watching it.
 func (b *PollBackend) Start(ctx context.Context, specs []WatchSpec, out chan<- Event) error {
 	b.UpdateSpecs(specs)
 
-	type tailerKey struct {
-		jailName string
-		path     string
+	type pathInfo struct {
+		jails       []string
+		readFromEnd bool
 	}
-	tailers := make(map[tailerKey]*FileTailer)
+
+	// tailers maps file path → FileTailer (one per unique path across all jails).
+	tailers := make(map[string]*FileTailer)
 
 	ticker := time.NewTicker(b.interval)
 	defer ticker.Stop()
@@ -57,56 +60,61 @@ func (b *PollBackend) Start(ctx context.Context, specs []WatchSpec, out chan<- E
 			}
 			return ctx.Err()
 		case <-ticker.C:
+			// Expand all globs for all specs: path → {jails watching it, readFromEnd}.
+			pathInfos := make(map[string]*pathInfo)
 			for _, spec := range b.getSpecs() {
-				matched := make(map[string]bool)
 				for _, pattern := range spec.Globs {
 					paths, err := filepath.Glob(pattern)
 					if err != nil {
 						continue
 					}
 					for _, p := range paths {
-						matched[p] = true
-					}
-				}
-
-				// Open tailers for newly seen files.
-				for p := range matched {
-					k := tailerKey{spec.JailName, p}
-					if _, ok := tailers[k]; !ok {
-						ft, err := NewFileTailer(p, true)
-						if err != nil {
-							continue
+						pi, ok := pathInfos[p]
+						if !ok {
+							pi = &pathInfo{readFromEnd: spec.ReadFromEnd}
+							pathInfos[p] = pi
 						}
-						tailers[k] = ft
+						pi.jails = append(pi.jails, spec.JailName)
 					}
 				}
+			}
 
-				// Read lines from existing tailers; remove tailers for gone files.
-				for k, ft := range tailers {
-					if k.jailName != spec.JailName {
-						continue
-					}
-					if !matched[k.path] {
-						ft.Close()
-						delete(tailers, k)
-						continue
-					}
-					lines, err := ft.ReadLines()
+			// Open tailers for newly seen paths.
+			for p, pi := range pathInfos {
+				if _, ok := tailers[p]; !ok {
+					ft, err := NewFileTailer(p, pi.readFromEnd)
 					if err != nil {
 						continue
 					}
-					for _, line := range lines {
+					tailers[p] = ft
+				}
+			}
+
+			// Read each file once; fan out lines to every jail watching it.
+			for p, ft := range tailers {
+				pi, matched := pathInfos[p]
+				if !matched {
+					ft.Close()
+					delete(tailers, p)
+					continue
+				}
+				lines, err := ft.ReadLines()
+				if err != nil {
+					continue
+				}
+				for _, line := range lines {
+					for _, jailName := range pi.jails {
 						if slog.Default().Enabled(ctx, slog.LevelDebug) && ft.debugLog.Allow() {
 							slog.DebugContext(ctx, "line notified",
-								"jail", k.jailName,
-								"file", k.path,
+								"jail", jailName,
+								"file", p,
 								"line", line,
 							)
 						}
 						select {
 						case out <- Event{
-							JailName: k.jailName,
-							FilePath: k.path,
+							JailName: jailName,
+							FilePath: p,
 							Offset:   ft.offset,
 							Line:     line,
 							Time:     time.Now(),

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -411,6 +411,95 @@ t.Errorf("expected FilePath %q, got %q", path, ev.FilePath)
 }
 }
 
+// TestPollBackendSharedFile verifies that when two jails watch the same file,
+// each line is delivered as a separate event to each jail (file read once per tick).
+func TestPollBackendSharedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.log")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	b := NewPollBackend(100 * time.Millisecond)
+	specs := []WatchSpec{
+		{JailName: "jail-a", Globs: []string{path}, ReadFromEnd: false},
+		{JailName: "jail-b", Globs: []string{path}, ReadFromEnd: false},
+	}
+	out, cancel := startBackend(t, b, specs)
+	defer cancel()
+
+	time.Sleep(150 * time.Millisecond)
+
+	af, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Fprintln(af, "shared line")
+	af.Close()
+
+	seen := make(map[string]bool)
+	for i := 0; i < 2; i++ {
+		ev, ok := waitEvent(out, 2*time.Second)
+		if !ok {
+			t.Fatalf("timed out waiting for event %d/2 (got jails: %v)", i+1, seen)
+		}
+		if ev.Line != "shared line" {
+			t.Errorf("expected line %q, got %q", "shared line", ev.Line)
+		}
+		seen[ev.JailName] = true
+	}
+	if !seen["jail-a"] || !seen["jail-b"] {
+		t.Errorf("expected events for both jails, got: %v", seen)
+	}
+}
+
+// TestFsnotifyBackendSharedFile mirrors TestPollBackendSharedFile for fsnotify.
+func TestFsnotifyBackendSharedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared-fsnotify.log")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	b := NewFsnotifyBackend(100 * time.Millisecond)
+	specs := []WatchSpec{
+		{JailName: "jail-c", Globs: []string{path}, ReadFromEnd: false},
+		{JailName: "jail-d", Globs: []string{path}, ReadFromEnd: false},
+	}
+	out, cancel := startBackend(t, b, specs)
+	defer cancel()
+
+	time.Sleep(150 * time.Millisecond)
+
+	af, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Fprintln(af, "shared fsnotify line")
+	af.Close()
+
+	seen := make(map[string]bool)
+	for i := 0; i < 2; i++ {
+		ev, ok := waitEvent(out, 2*time.Second)
+		if !ok {
+			t.Fatalf("timed out waiting for event %d/2 (got jails: %v)", i+1, seen)
+		}
+		if ev.Line != "shared fsnotify line" {
+			t.Errorf("expected line %q, got %q", "shared fsnotify line", ev.Line)
+		}
+		seen[ev.JailName] = true
+	}
+	if !seen["jail-c"] || !seen["jail-d"] {
+		t.Errorf("expected events for both jails, got: %v", seen)
+	}
+}
+
 // TestDebugRateLimiterInWatch verifies the watch package's debugRateLimiter
 // allows exactly maxPerSec entries per window and resets after one second.
 func TestDebugRateLimiterInWatch(t *testing.T) {


### PR DESCRIPTION
Previously each jail had its own FileTailer per file path, keyed by (jailName, path). With N jails watching M shared files this meant:
- N×M os.Stat() + Read() syscalls per tick (poll) or per write event (fsnotify)
- O(N²) iteration in the poll backend (for each spec, scan all tailers)

Now each backend maintains one FileTailer per unique file path. Lines are read once per tick/event and fanned out to every jail whose globs match that path, reducing syscalls from N×M to M.

Changes:
- poll.go: replace tailerKey{jailName,path} map with map[path]; build pathInfos{jails,readFromEnd} each tick from all specs; read each file once and emit events for all watching jails.
- fsnotify.go: same per-path tailer approach; rescan() now rebuilds pathToJails from scratch each tick to correctly handle jail additions/removals; readAndSend(path) fans out to all watching jails.
- watch_test.go: add TestPollBackendSharedFile and TestFsnotifyBackendSharedFile verifying two jails both receive events when they watch the same file.