### PR TITLE
fix: logging improvements (issue #13)

### DIFF
--- a/internal/action/runner.go
+++ b/internal/action/runner.go
@@ -6,11 +6,18 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strings"
 	"text/template"
 	"time"
 )
 
 const defaultTimeout = 10 * time.Second
+
+// cleanOutput trims trailing newlines then replaces remaining interior newlines with "; ".
+func cleanOutput(s string) string {
+	s = strings.TrimRight(s, "\n")
+	return strings.ReplaceAll(s, "\n", "; ")
+}
 
 // Result holds the outcome of running a single command.
 type Result struct {
@@ -72,10 +79,10 @@ func Run(ctx context.Context, tmpl string, actCtx Context, timeout time.Duration
 		Error:    runErr,
 	}
 
-	slog.Info("action run",
+	slog.Info("ACTN run",
 		"command", rendered,
-		"stdout", result.Stdout,
-		"stderr", result.Stderr,
+		"stdout", cleanOutput(result.Stdout),
+		"stderr", cleanOutput(result.Stderr),
 		"exitCode", exitCode,
 	)
 
@@ -120,10 +127,10 @@ func RunCompiled(ctx context.Context, tmpl *template.Template, actCtx Context, t
 		Error:    runErr,
 	}
 
-	slog.Info("action run",
+	slog.Info("ACTN run",
 		"command", rendered,
-		"stdout", result.Stdout,
-		"stderr", result.Stderr,
+		"stdout", cleanOutput(result.Stdout),
+		"stderr", cleanOutput(result.Stderr),
 		"exitCode", exitCode,
 	)
 

--- a/internal/engine/jail_runtime.go
+++ b/internal/engine/jail_runtime.go
@@ -518,9 +518,10 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			return nil
 		}
 
-		slog.Info("hit threshold reached, running on_add",
+		slog.Info("JAIL on_add",
 			"jail", cfg.Name,
 			"ip", result.IP,
+			"label", result.Label,
 			"count", count,
 			"threshold", threshold,
 		)

--- a/internal/filter/extract.go
+++ b/internal/filter/extract.go
@@ -24,3 +24,18 @@ func Extract(re *regexp.Regexp, line string) string {
 	}
 	return ""
 }
+
+// ExtractLabel attempts to get the "label" named capture group from a regex match on line.
+// Returns "" if no named "label" group exists or it didn't match.
+func ExtractLabel(re *regexp.Regexp, line string) string {
+	match := re.FindStringSubmatch(line)
+	if match == nil {
+		return ""
+	}
+	for i, name := range re.SubexpNames() {
+		if name == "label" && i < len(match) {
+			return match[i]
+		}
+	}
+	return ""
+}

--- a/internal/filter/match.go
+++ b/internal/filter/match.go
@@ -3,6 +3,7 @@ package filter
 // Result is returned from a successful match.
 type Result struct {
 	IP      string // extracted IP or CIDR text
+	Label   string // extracted label text (from (?P<label>...) group), may be empty
 	Line    string // original log line
 	Pattern string // matched filter pattern
 }
@@ -35,10 +36,12 @@ func Match(line string, includes, excludes []*CompiledFilter) (*Result, error) {
 
 	// Step 4: extract IP from named (or first) capture group.
 	ip := Extract(matched.re, line)
+	label := ExtractLabel(matched.re, line)
 
 	// Step 5: return result.
 	return &Result{
 		IP:      ip,
+		Label:   label,
 		Line:    line,
 		Pattern: matched.pattern,
 	}, nil


### PR DESCRIPTION
Closes #13

## Changes

- Change log message `hit threshold reached, running on_add` → `JAIL on_add`
- Change log message `action run` → `ACTN run`
- Add `label` extraction from a `(?P<label>...)` named capture group in filter regex (parallel to how `ip` is extracted via `(?P<ip>...)`)
- Include `label` field in the `JAIL on_add` log entry so context (e.g. website domain) is visible alongside the banned IP
- Trim trailing `\n` from action stdout/stderr before logging; replace any remaining interior `\n` with `; `