### PR TITLE
fix: perf api improvements (issue #14)

### DIFF
--- a/cmd/jailtime/main.go
+++ b/cmd/jailtime/main.go
@@ -175,7 +175,7 @@ matched. No hit counts are modified and no actions are executed.`,
 	perfCmd := &cobra.Command{
 		Use:   "perf",
 		Short: "Show daemon performance metrics",
-		Long:  "Display current latency, execution delay, average execution time, and CPU usage.",
+		Long:  "Display target latency config and current latency, execution, sleep, lines processed, and CPU usage.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := client()
@@ -183,11 +183,14 @@ matched. No hit counts are modified and no actions are executed.`,
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Performance Metrics (window=%d):\n", resp.WindowSize)
-			fmt.Printf("  Current latency:     %.0fms\n", resp.CurrentLatencyMs)
-			fmt.Printf("  Current interval:    %.0fms\n", resp.CurrentIntervalMs)
-			fmt.Printf("  Avg execution time:  %.1fms\n", resp.AvgExecTimeMs)
-			fmt.Printf("  Avg CPU usage:       %.1f%%\n", resp.AvgCPUPercent)
+			fmt.Printf("Config:\n")
+			fmt.Printf("  Target Latency: %.0fms\n", resp.TargetLatencyMs)
+			fmt.Printf("\nPerformance:\n")
+			fmt.Printf("  Latency:   %.0fms\n", resp.LatencyMs)
+			fmt.Printf("  Execution: %.0fms\n", resp.ExecutionMs)
+			fmt.Printf("  Sleep:     %.0fms\n", resp.SleepMs)
+			fmt.Printf("  Lines:     %d\n", resp.LinesProcessed)
+			fmt.Printf("  CPU Usage: %.1f%%\n", resp.CPUPercent)
 			return nil
 		},
 	}

--- a/cmd/jailtimed/main.go
+++ b/cmd/jailtimed/main.go
@@ -175,11 +175,12 @@ func (a *JailControllerAdapter) ConfigTest(name, filePath string, limit int, ret
 func (a *JailControllerAdapter) PerfStats() control.PerfResponse {
 	snap := a.m.PerfStats()
 	return control.PerfResponse{
-		CurrentLatencyMs:  snap.CurrentLatencyMs,
-		CurrentIntervalMs: snap.CurrentIntervalMs,
-		AvgExecTimeMs:     snap.AvgExecTimeMs,
-		AvgCPUPercent:     snap.AvgCPUPercent,
-		WindowSize:        snap.WindowSize,
+		TargetLatencyMs: snap.TargetLatencyMs,
+		LatencyMs:       snap.LatencyMs,
+		ExecutionMs:     snap.ExecutionMs,
+		SleepMs:         snap.SleepMs,
+		LinesProcessed:  snap.LinesProcessed,
+		CPUPercent:      snap.CPUPercent,
 	}
 }
 

--- a/internal/control/api.go
+++ b/internal/control/api.go
@@ -36,11 +36,12 @@ type ConfigTestResponse struct {
 
 // PerfResponse is returned by GET /v1/perf.
 type PerfResponse struct {
-	CurrentLatencyMs  float64 `json:"current_latency_ms"`
-	CurrentIntervalMs float64 `json:"current_interval_ms"`
-	AvgExecTimeMs     float64 `json:"avg_exec_time_ms"`
-	AvgCPUPercent     float64 `json:"avg_cpu_percent"`
-	WindowSize        int     `json:"window_size"`
+	TargetLatencyMs float64 `json:"target_latency_ms"`
+	LatencyMs       float64 `json:"latency_ms"`
+	ExecutionMs     float64 `json:"execution_ms"`
+	SleepMs         float64 `json:"sleep_ms"`
+	LinesProcessed  int     `json:"lines_processed"`
+	CPUPercent      float64 `json:"cpu_percent"`
 }
 
 // WhitelistStatusResponse represents one whitelist's status.

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -22,6 +22,7 @@ type Manager struct {
 	perf            *PerfMetrics
 	currentInterval time.Duration
 	lastDrainAt     time.Time
+	lastExecTime    time.Duration
 }
 
 func NewManager(cfg *config.Config, configPath string) (*Manager, error) {
@@ -51,18 +52,13 @@ func NewManager(cfg *config.Config, configPath string) (*Manager, error) {
 	}
 	backend := watch.NewAuto(cfg.Engine.WatcherMode, targetLatency)
 
-	perfWindow := cfg.Engine.PerfWindow
-	if perfWindow == 0 {
-		perfWindow = 3
-	}
-
 	m := &Manager{
 		cfg:             cfg,
 		configPath:      configPath,
 		jails:           jails,
 		whitelists:      whitelists,
 		backend:         backend,
-		perf:            NewPerfMetrics(perfWindow, "jailtimed.service"),
+		perf:            NewPerfMetrics(targetLatency, "jailtimed.service"),
 		currentInterval: targetLatency,
 	}
 	m.injectIgnoreSets()
@@ -123,10 +119,14 @@ func (m *Manager) processDrain(ctx context.Context, lines []watch.RawLine) {
 	}
 	m.lastDrainAt = drainStart
 
+	// Sleep time = interval since last drain minus the previous drain's execution time.
+	sleepTime := m.currentInterval - m.lastExecTime
+
 	m.processBatch(ctx, lines)
 
 	execTime := time.Since(drainStart)
-	m.perf.RecordExecution(execTime, m.currentInterval, len(lines))
+	m.perf.RecordExecution(execTime, m.currentInterval, sleepTime, len(lines))
+	m.lastExecTime = execTime
 }
 
 func (m *Manager) processBatch(ctx context.Context, lines []watch.RawLine) {

--- a/internal/engine/perf.go
+++ b/internal/engine/perf.go
@@ -7,82 +7,50 @@ import (
 
 // PerfSnapshot is a point-in-time view of performance metrics.
 type PerfSnapshot struct {
-	CurrentLatencyMs  float64 `json:"current_latency_ms"`
-	CurrentIntervalMs float64 `json:"current_interval_ms"`
-	AvgExecTimeMs     float64 `json:"avg_exec_time_ms"`
-	AvgCPUPercent     float64 `json:"avg_cpu_percent"`
-	WindowSize        int     `json:"window_size"`
+	TargetLatencyMs float64 `json:"target_latency_ms"`
+	LatencyMs       float64 `json:"latency_ms"`
+	ExecutionMs     float64 `json:"execution_ms"`
+	SleepMs         float64 `json:"sleep_ms"`
+	LinesProcessed  int     `json:"lines_processed"`
+	CPUPercent      float64 `json:"cpu_percent"`
 }
 
-// PerfMetrics collects performance metrics in circular buffers.
+// PerfMetrics collects performance metrics.
 type PerfMetrics struct {
 	mu sync.RWMutex
 
-	windowSize int
+	targetLatency time.Duration
 
-	latencies    []time.Duration // circular buffer
-	latencyIdx   int
-	latencyCount int
-
-	execTimes []time.Duration // circular buffer
-	execIdx   int
-	execCount int
-
-	cpuSamples []float64 // circular buffer
-	cpuIdx     int
-	cpuCount   int
-
-	currentInterval time.Duration
-	currentLatency  time.Duration
+	lastLatency   time.Duration
+	lastExec      time.Duration
+	lastSleep     time.Duration
+	lastLines     int
 
 	cpuSampler *cgroupCPUSampler
+	lastCPU    float64
 }
 
-func NewPerfMetrics(windowSize int, serviceName string) *PerfMetrics {
-	if windowSize <= 0 {
-		windowSize = 1
-	}
+func NewPerfMetrics(targetLatency time.Duration, serviceName string) *PerfMetrics {
 	return &PerfMetrics{
-		windowSize: windowSize,
-		latencies:  make([]time.Duration, windowSize),
-		execTimes:  make([]time.Duration, windowSize),
-		cpuSamples: make([]float64, windowSize),
-		cpuSampler: newCgroupCPUSampler(serviceName),
+		targetLatency: targetLatency,
+		cpuSampler:    newCgroupCPUSampler(serviceName),
 	}
 }
 
 // RecordExecution is called after each batch drain.
+// sleepTime is the duration the backend slept before this drain.
 // batchSize 0 means no lines were processed; CPU is not sampled in that case.
-func (p *PerfMetrics) RecordExecution(execTime, currentInterval time.Duration, batchSize int) {
+func (p *PerfMetrics) RecordExecution(execTime, latency, sleepTime time.Duration, batchSize int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.currentInterval = currentInterval
-
-	// Push exec time
-	p.execTimes[p.execIdx%p.windowSize] = execTime
-	p.execIdx++
-	if p.execCount < p.windowSize {
-		p.execCount++
-	}
+	p.lastExec = execTime
+	p.lastLatency = latency
+	p.lastSleep = sleepTime
+	p.lastLines = batchSize
 
 	if batchSize > 0 {
-		p.currentLatency = execTime
-
-		// Push latency
-		p.latencies[p.latencyIdx%p.windowSize] = execTime
-		p.latencyIdx++
-		if p.latencyCount < p.windowSize {
-			p.latencyCount++
-		}
-
-		// Push CPU — only sample when there was actual work to do.
-		cpuPct := p.cpuSampler.Sample()
-		p.cpuSamples[p.cpuIdx%p.windowSize] = cpuPct
-		p.cpuIdx++
-		if p.cpuCount < p.windowSize {
-			p.cpuCount++
-		}
+		p.lastCPU = p.cpuSampler.Sample()
 	}
 }
 
@@ -97,32 +65,11 @@ func (p *PerfMetrics) Snapshot() PerfSnapshot {
 	defer p.mu.RUnlock()
 
 	return PerfSnapshot{
-		CurrentLatencyMs:  float64(p.currentLatency.Microseconds()) / 1000.0,
-		CurrentIntervalMs: float64(p.currentInterval.Microseconds()) / 1000.0,
-		AvgExecTimeMs:     avgDurationMs(p.execTimes, p.execCount),
-		AvgCPUPercent:     avgFloat(p.cpuSamples, p.cpuCount),
-		WindowSize:        p.windowSize,
+		TargetLatencyMs: float64(p.targetLatency.Microseconds()) / 1000.0,
+		LatencyMs:       float64(p.lastLatency.Microseconds()) / 1000.0,
+		ExecutionMs:     float64(p.lastExec.Microseconds()) / 1000.0,
+		SleepMs:         float64(p.lastSleep.Microseconds()) / 1000.0,
+		LinesProcessed:  p.lastLines,
+		CPUPercent:      p.lastCPU,
 	}
-}
-
-func avgDurationMs(buf []time.Duration, count int) float64 {
-	if count == 0 {
-		return 0
-	}
-	var sum time.Duration
-	for i := 0; i < count; i++ {
-		sum += buf[i]
-	}
-	return float64(sum.Microseconds()) / 1000.0 / float64(count)
-}
-
-func avgFloat(buf []float64, count int) float64 {
-	if count == 0 {
-		return 0
-	}
-	var sum float64
-	for i := 0; i < count; i++ {
-		sum += buf[i]
-	}
-	return sum / float64(count)
 }

--- a/internal/engine/perf_test.go
+++ b/internal/engine/perf_test.go
@@ -5,92 +5,52 @@ import (
 	"time"
 )
 
-func TestPerfMetrics_SnapshotAverages(t *testing.T) {
-	p := NewPerfMetrics(5, "nonexistent-service-for-test.service")
+func TestPerfMetrics_SnapshotLastValues(t *testing.T) {
+	p := NewPerfMetrics(2*time.Second, "nonexistent-service-for-test.service")
 
-	execTimes := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
-
-	// Push exec times; first two with batchSize=1 (records latency/CPU), third is idle.
-	for i, et := range execTimes {
-		bs := 0
-		if i < 2 {
-			bs = 1
-		}
-		p.RecordExecution(et, 100*time.Millisecond, bs)
-	}
+	p.RecordExecution(10*time.Millisecond, 100*time.Millisecond, 90*time.Millisecond, 5)
+	p.RecordExecution(30*time.Millisecond, 120*time.Millisecond, 95*time.Millisecond, 8)
 
 	snap := p.Snapshot()
 
-	wantAvgExec := 20.0 // (10+20+30)/3
-	if snap.AvgExecTimeMs != wantAvgExec {
-		t.Errorf("AvgExecTimeMs = %v, want %v", snap.AvgExecTimeMs, wantAvgExec)
+	if snap.TargetLatencyMs != 2000.0 {
+		t.Errorf("TargetLatencyMs = %v, want 2000.0", snap.TargetLatencyMs)
 	}
-
-	wantInterval := 100.0
-	if snap.CurrentIntervalMs != wantInterval {
-		t.Errorf("CurrentIntervalMs = %v, want %v", snap.CurrentIntervalMs, wantInterval)
+	if snap.ExecutionMs != 30.0 {
+		t.Errorf("ExecutionMs = %v, want 30.0 (last value)", snap.ExecutionMs)
 	}
-
-	if snap.WindowSize != 5 {
-		t.Errorf("WindowSize = %v, want 5", snap.WindowSize)
+	if snap.LatencyMs != 120.0 {
+		t.Errorf("LatencyMs = %v, want 120.0 (last value)", snap.LatencyMs)
+	}
+	if snap.SleepMs != 95.0 {
+		t.Errorf("SleepMs = %v, want 95.0 (last value)", snap.SleepMs)
+	}
+	if snap.LinesProcessed != 8 {
+		t.Errorf("LinesProcessed = %v, want 8 (last value)", snap.LinesProcessed)
 	}
 }
 
-func TestPerfMetrics_CircularBufferWrapping(t *testing.T) {
-	const windowSize = 3
-	p := NewPerfMetrics(windowSize, "nonexistent-service-for-test.service")
-
-	// Push windowSize+2 items: 10, 20, 30, 40, 50 ms
-	values := []time.Duration{10, 20, 30, 40, 50}
-	for _, v := range values {
-		p.RecordExecution(v*time.Millisecond, 0, 0)
-	}
-
-	// After wrapping with windowSize=3 and 5 items:
-	//   idx=0: 10 → overwritten by idx=3 (40)  → slot 0 = 40
-	//   idx=1: 20 → overwritten by idx=4 (50)  → slot 1 = 50
-	//   idx=2: 30                               → slot 2 = 30
-	// avg of buf[0..2] = (40+50+30)/3 = 40ms
-	snap := p.Snapshot()
-	wantAvg := 40.0
-	if snap.AvgExecTimeMs != wantAvg {
-		t.Errorf("AvgExecTimeMs after wrap = %v, want %v", snap.AvgExecTimeMs, wantAvg)
-	}
-}
-
-func TestPerfMetrics_BatchSizeZeroSkipsLatency(t *testing.T) {
-	p := NewPerfMetrics(5, "nonexistent-service-for-test.service")
-
-	// Call with batchSize=0 — latency and CPU should not be recorded
-	p.RecordExecution(5*time.Millisecond, 50*time.Millisecond, 0)
-
+func TestPerfMetrics_ZeroBeforeFirstRecord(t *testing.T) {
+	p := NewPerfMetrics(2*time.Second, "nonexistent-service-for-test.service")
 	snap := p.Snapshot()
 
-	// currentLatency was never set (batchSize was 0)
-	if snap.CurrentLatencyMs != 0 {
-		t.Errorf("CurrentLatencyMs = %v, want 0 (batchSize was 0)", snap.CurrentLatencyMs)
+	if snap.ExecutionMs != 0 {
+		t.Errorf("ExecutionMs = %v before any record, want 0", snap.ExecutionMs)
 	}
-
-	// exec time was still recorded
-	if snap.AvgExecTimeMs != 5.0 {
-		t.Errorf("AvgExecTimeMs = %v, want 5.0", snap.AvgExecTimeMs)
+	if snap.LatencyMs != 0 {
+		t.Errorf("LatencyMs = %v before any record, want 0", snap.LatencyMs)
 	}
-
-	// latency buffer count should be 0; verify via internal field
-	p.mu.RLock()
-	lc := p.latencyCount
-	p.mu.RUnlock()
-	if lc != 0 {
-		t.Errorf("latencyCount = %d, want 0", lc)
+	if snap.LinesProcessed != 0 {
+		t.Errorf("LinesProcessed = %v before any record, want 0", snap.LinesProcessed)
 	}
 }
 
 func TestPerfMetrics_UnavailableCgroupNoPanic(t *testing.T) {
-	// Must not panic even when cgroup path doesn't exist
-	p := NewPerfMetrics(10, "no-such-service-xyz-123.service")
-	p.RecordExecution(1*time.Millisecond, 10*time.Millisecond, 1)
+	// Must not panic even when cgroup path doesn't exist.
+	p := NewPerfMetrics(2*time.Second, "no-such-service-xyz-123.service")
+	p.RecordExecution(1*time.Millisecond, 10*time.Millisecond, 9*time.Millisecond, 1)
 	snap := p.Snapshot()
-	if snap.WindowSize != 10 {
-		t.Errorf("WindowSize = %v, want 10", snap.WindowSize)
+	if snap.TargetLatencyMs != 2000.0 {
+		t.Errorf("TargetLatencyMs = %v, want 2000.0", snap.TargetLatencyMs)
 	}
 }


### PR DESCRIPTION
Closes #14

## Changes

Redesigns the performance metrics API to show last-recorded values and adds the missing fields requested in the issue.

**`jailtime perf` output now matches the requested format:**
```
Config:
  Target Latency: 2000ms

Performance:
  Latency:   2013ms
  Execution: 213ms
  Sleep:     1895ms
  Lines:     321
  CPU Usage: 0.0%
```

**API / struct changes (`PerfResponse` / `PerfSnapshot`):**
- `TargetLatencyMs` — configured target latency (new)
- `LatencyMs` — interval between last two drain calls (replaces `CurrentIntervalMs`)
- `ExecutionMs` — last drain execution time (replaces windowed `AvgExecTimeMs`)
- `SleepMs` — computed as `latency - previousExecTime` (new)
- `LinesProcessed` — line count from the last drain batch (new)
- `CPUPercent` — CPU sampled after last non-empty batch (replaces `AvgCPUPercent`)
- Removed `WindowSize` (no longer windowed)

**Implementation:**
- `PerfMetrics` simplified: replaces circular buffers with simple last-value fields
- `Manager.processDrain` tracks `lastExecTime` to compute sleep time
- `perf_test.go` updated for the new last-value semantics