### PR TITLE
feat: global on_start/on_stop actions and sorted jail startup order

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -558,6 +558,41 @@ whitelists:
 	}
 }
 
+func TestLoadGlobalActions(t *testing.T) {
+	y := minimalValidYAML + `
+actions:
+  on_start:
+    - "echo 'global on_start'"
+  on_stop:
+    - "echo 'global on_stop'"
+`
+	path := writeTemp(t, y)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(c.Actions.OnStart) != 1 || c.Actions.OnStart[0] != "echo 'global on_start'" {
+		t.Errorf("Actions.OnStart = %v, want [\"echo 'global on_start'\"]", c.Actions.OnStart)
+	}
+	if len(c.Actions.OnStop) != 1 || c.Actions.OnStop[0] != "echo 'global on_stop'" {
+		t.Errorf("Actions.OnStop = %v, want [\"echo 'global on_stop'\"]", c.Actions.OnStop)
+	}
+}
+
+func TestLoadGlobalActionsDefault(t *testing.T) {
+	path := writeTemp(t, minimalValidYAML)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(c.Actions.OnStart) != 0 {
+		t.Errorf("Actions.OnStart should be empty by default, got %v", c.Actions.OnStart)
+	}
+	if len(c.Actions.OnStop) != 0 {
+		t.Errorf("Actions.OnStop should be empty by default, got %v", c.Actions.OnStop)
+	}
+}
+
 func TestLoadWatchModeDefault(t *testing.T) {
 	path := writeTemp(t, minimalValidYAML)
 	c, err := Load(path)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -46,6 +46,7 @@ type rawConfig struct {
 	Logging    LoggingConfig   `yaml:"logging"`
 	Control    ControlConfig   `yaml:"control"`
 	Engine     rawEngineConfig `yaml:"engine"`
+	Actions    GlobalActions   `yaml:"actions"`
 	Jails      []rawJailConfig `yaml:"jails"`
 	Whitelists []rawJailConfig `yaml:"whitelists"`
 }
@@ -105,6 +106,7 @@ func Load(path string) (*Config, error) {
 			PollInterval:  raw.Engine.PollInterval,
 			TargetLatency: raw.Engine.TargetLatency,
 		},
+		Actions: raw.Actions,
 	}
 
 	for _, rj := range raw.Jails {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+// GlobalActions holds the shell commands run at daemon start and stop, before
+// any jail or whitelist is started / after all have stopped.
+type GlobalActions struct {
+	OnStart []string `yaml:"on_start"`
+	OnStop  []string `yaml:"on_stop"`
+}
+
 // Config is the top-level configuration structure.
 type Config struct {
 	Version    int           `yaml:"version"`
@@ -12,6 +19,7 @@ type Config struct {
 	Logging    LoggingConfig `yaml:"logging"`
 	Control    ControlConfig `yaml:"control"`
 	Engine     EngineConfig  `yaml:"engine"`
+	Actions    GlobalActions `yaml:"actions"`
 	Jails      []JailConfig  `yaml:"jails"`
 	Whitelists []JailConfig  `yaml:"whitelists"`
 }
@@ -105,6 +113,9 @@ const defaultPollInterval = 2 * time.Second
 
 // defaultActionTimeout is the per-command timeout for on_match and query actions.
 const defaultActionTimeout = 30 * time.Second
+
+// DefaultActionTimeout is the exported default for per-action timeouts.
+const DefaultActionTimeout = defaultActionTimeout
 
 const defaultTargetLatency = 2 * time.Second
 const defaultPerfWindow = 3

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
+	"github.com/sgw/jailtime/internal/action"
 	"github.com/sgw/jailtime/internal/config"
 	"github.com/sgw/jailtime/internal/watch"
 )
@@ -67,9 +69,21 @@ func NewManager(cfg *config.Config, configPath string) (*Manager, error) {
 
 // Run starts all enabled whitelists (before jails so membership is available),
 // then starts all enabled jails, then starts the watch backend.
+// Global on_start actions run before any whitelist or jail is started;
+// global on_stop actions run after all have stopped.
+// Within each group, start/stop order is alphabetical by name.
 func (m *Manager) Run(ctx context.Context) error {
-	// Start whitelists first so their static membership is ready before jails process events.
-	for name, jr := range m.whitelists {
+	// Run global on_start actions before starting any jail or whitelist.
+	if len(m.cfg.Actions.OnStart) > 0 {
+		actCtx := action.Context{Timestamp: nowUTC()}
+		if _, err := action.RunAll(ctx, m.cfg.Actions.OnStart, actCtx, config.DefaultActionTimeout); err != nil {
+			return fmt.Errorf("global on_start: %w", err)
+		}
+	}
+
+	// Start whitelists first (alphabetical) so their static membership is ready before jails process events.
+	for _, name := range sortedKeys(m.whitelists) {
+		jr := m.whitelists[name]
 		if !jr.cfg.Enabled {
 			continue
 		}
@@ -77,7 +91,9 @@ func (m *Manager) Run(ctx context.Context) error {
 			return fmt.Errorf("starting whitelist %q: %w", name, err)
 		}
 	}
-	for name, jr := range m.jails {
+	// Start jails in alphabetical order.
+	for _, name := range sortedKeys(m.jails) {
+		jr := m.jails[name]
 		if !jr.cfg.Enabled {
 			continue
 		}
@@ -105,6 +121,14 @@ func (m *Manager) Run(ctx context.Context) error {
 	}
 	m.mu.RUnlock()
 	m.perf.Close()
+
+	// Run global on_stop actions after all jails and whitelists have stopped.
+	if len(m.cfg.Actions.OnStop) > 0 {
+		actCtx := action.Context{Timestamp: nowUTC()}
+		if _, stopErr := action.RunAll(stopCtx, m.cfg.Actions.OnStop, actCtx, config.DefaultActionTimeout); stopErr != nil {
+			slog.Warn("global on_stop action failed", "error", stopErr)
+		}
+	}
 
 	if err != nil && err != context.Canceled {
 		return fmt.Errorf("watch backend: %w", err)
@@ -341,6 +365,21 @@ func buildSpecs(jails map[string]*JailRuntime, readFromEnd bool) []watch.WatchSp
 		}
 	}
 	return specs
+}
+
+// sortedKeys returns the keys of m in sorted order.
+func sortedKeys(m map[string]*JailRuntime) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// nowUTC returns the current time formatted as RFC3339 in UTC.
+func nowUTC() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }
 
 // JailStatus returns the status of a jail by name.

--- a/internal/engine/manager_test.go
+++ b/internal/engine/manager_test.go
@@ -2,13 +2,174 @@ package engine
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/sgw/jailtime/internal/config"
 	"github.com/sgw/jailtime/internal/watch"
 )
 
-// TestManagerCurrentInterval verifies that processDrain measures currentInterval
+// TestSortedKeys verifies that sortedKeys returns map keys in alphabetical order.
+func TestSortedKeys(t *testing.T) {
+	m := map[string]*JailRuntime{
+		"zebra":  {},
+		"alpha":  {},
+		"middle": {},
+	}
+	got := sortedKeys(m)
+	want := []string{"alpha", "middle", "zebra"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("sortedKeys = %v, want %v", got, want)
+	}
+}
+
+// makeMinimalJailCfg creates a minimal enabled JailConfig that appends the jail
+// name to outFile when started (on_start action).
+func makeMinimalJailCfg(name, logFile, outFile string) *config.JailConfig {
+	return &config.JailConfig{
+		Name:    name,
+		Enabled: true,
+		Files:   []string{logFile},
+		Filters: []string{`(?P<ip>[0-9.]+)`},
+		Actions: config.JailActions{
+			OnStart: []string{fmt.Sprintf("echo %s >> %s", name, outFile)},
+			OnAdd:   []string{"echo {{ .IP }}"},
+		},
+		HitCount:      1,
+		FindTime:      config.Duration{Duration: time.Minute},
+		JailTime:      config.Duration{Duration: time.Hour},
+		NetType:       "IP",
+		WatchMode:     "tail",
+		ActionTimeout: config.Duration{Duration: 5 * time.Second},
+	}
+}
+
+// TestGlobalOnStartRunsBeforeJails verifies that global on_start actions execute
+// before any jail on_start action.
+func TestGlobalOnStartRunsBeforeJails(t *testing.T) {
+	dir := t.TempDir()
+	outFile := dir + "/order.txt"
+	logFile := dir + "/app.log"
+	// Create the log file so the jail glob matches.
+	if err := os.WriteFile(logFile, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Actions: config.GlobalActions{
+			OnStart: []string{fmt.Sprintf("echo global >> %s", outFile)},
+		},
+		Engine: config.EngineConfig{
+			WatcherMode:   "poll",
+			PollInterval:  config.Duration{Duration: 50 * time.Millisecond},
+			ReadFromEnd:   true,
+			TargetLatency: config.Duration{Duration: 50 * time.Millisecond},
+			PerfWindow:    1,
+		},
+	}
+
+	jailCfg := makeMinimalJailCfg("alpha", logFile, outFile)
+	jr, err := NewJailRuntime(jailCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{
+		cfg:        cfg,
+		jails:      map[string]*JailRuntime{"alpha": jr},
+		whitelists: map[string]*JailRuntime{},
+		backend:    watch.NewAuto("poll", 50*time.Millisecond),
+		perf:       NewPerfMetrics(50*time.Millisecond, ""),
+	}
+	m.currentInterval = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Run(ctx)
+	}()
+	// Allow enough time for on_start actions to fire.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines in output, got: %v", lines)
+	}
+	if lines[0] != "global" {
+		t.Errorf("first line = %q, want \"global\" (global on_start must fire before jail on_start)", lines[0])
+	}
+	if lines[1] != "alpha" {
+		t.Errorf("second line = %q, want \"alpha\"", lines[1])
+	}
+}
+
+// TestJailsStartInAlphabeticalOrder verifies that jails are started in sorted order.
+func TestJailsStartInAlphabeticalOrder(t *testing.T) {
+	dir := t.TempDir()
+	outFile := dir + "/order.txt"
+	logFile := dir + "/app.log"
+	if err := os.WriteFile(logFile, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			WatcherMode:   "poll",
+			PollInterval:  config.Duration{Duration: 50 * time.Millisecond},
+			ReadFromEnd:   true,
+			TargetLatency: config.Duration{Duration: 50 * time.Millisecond},
+			PerfWindow:    1,
+		},
+	}
+
+	jails := map[string]*JailRuntime{}
+	for _, name := range []string{"zebra", "alpha", "middle"} {
+		jailCfg := makeMinimalJailCfg(name, logFile, outFile)
+		jr, err := NewJailRuntime(jailCfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jails[name] = jr
+	}
+
+	m := &Manager{
+		cfg:        cfg,
+		jails:      jails,
+		whitelists: map[string]*JailRuntime{},
+		backend:    watch.NewAuto("poll", 50*time.Millisecond),
+		perf:       NewPerfMetrics(50*time.Millisecond, ""),
+	}
+	m.currentInterval = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Run(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{"alpha", "middle", "zebra"}
+	if fmt.Sprint(lines) != fmt.Sprint(want) {
+		t.Errorf("jail startup order = %v, want %v", lines, want)
+	}
+}
+
 // as the elapsed time between successive drain calls.
 func TestManagerCurrentInterval(t *testing.T) {
 	m := &Manager{


### PR DESCRIPTION
Fixes #19

## Changes

### Global actions in jail.yaml
Adds a top-level actions: key to the main config file supporting on_start and on_stop command lists.

Global on_start actions run synchronously before any whitelist or jail is started, ensuring firewall chains are set up first. Global on_stop actions run after all jails and whitelists have stopped.

### Sorted startup order
- Whitelists and jails are now started in alphabetical order by name (was non-deterministic due to Go map iteration)
- Ensures deterministic ordering when multiple jails/whitelists are loaded from fragment files

## Files changed
- internal/config/types.go -- add GlobalActions struct and Actions field on Config; export DefaultActionTimeout
- internal/config/load.go -- parse actions: from YAML into Config.Actions
- internal/engine/manager.go -- run global on_start/on_stop; iterate jails/whitelists in sorted order