### PR TITLE
feat: add runtime global config read/write API (issue #21)

### DIFF
--- a/cmd/jailtime/main.go
+++ b/cmd/jailtime/main.go
@@ -197,6 +197,46 @@ matched. No hit counts are modified and no actions are executed.`,
 
 	configCmd.AddCommand(filesCmd, testCmd)
 
+	// config global [<key> <value>]
+	globalCmd := &cobra.Command{
+		Use:   "global [<key> <value>]",
+		Short: "Read or update global engine configuration at runtime",
+		Long: `Without arguments, lists all global engine config fields (excluding actions).
+With <key> and <value>, updates the named field immediately in the running daemon.
+
+Settable keys: target_latency, poll_interval, watcher_mode, read_from_end, perf_window.
+Duration values use Go duration syntax, e.g. "2s", "500ms", "1m".`,
+		Example: `  jailtime config global
+  jailtime config global target_latency 5s
+  jailtime config global perf_window 5`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || len(args) == 2 {
+				return nil
+			}
+			return fmt.Errorf("accepts 0 or 2 arguments, got %d", len(args))
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := client()
+			if len(args) == 2 {
+				return c.SetGlobalConfig(args[0], args[1])
+			}
+			resp, err := c.GlobalConfig()
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "KEY\tVALUE")
+			keys := []string{"watcher_mode", "poll_interval", "read_from_end", "target_latency", "perf_window"}
+			for _, k := range keys {
+				if v, ok := resp.Config[k]; ok {
+					fmt.Fprintf(tw, "%s\t%s\n", k, v)
+				}
+			}
+			return tw.Flush()
+		},
+	}
+	configCmd.AddCommand(globalCmd)
+
 	// ── whitelist ─────────────────────────────────────────────────────────────
 	whitelistCmd := &cobra.Command{
 		Use:   "whitelist",

--- a/cmd/jailtimed/main.go
+++ b/cmd/jailtimed/main.go
@@ -209,3 +209,11 @@ func (a *JailControllerAdapter) AllWhitelistStatuses() map[string]string {
 	}
 	return out
 }
+
+func (a *JailControllerAdapter) GlobalConfig() map[string]string {
+	return a.m.GlobalConfig()
+}
+
+func (a *JailControllerAdapter) SetGlobalConfig(key, value string) error {
+	return a.m.SetGlobalConfig(key, value)
+}

--- a/internal/control/api.go
+++ b/internal/control/api.go
@@ -44,7 +44,16 @@ type PerfResponse struct {
 	CPUPercent      float64 `json:"cpu_percent"`
 }
 
-// WhitelistStatusResponse represents one whitelist's status.
+// GlobalConfigResponse is returned by GET /v1/config/global.
+type GlobalConfigResponse struct {
+	Config map[string]string `json:"config"`
+}
+
+// SetGlobalConfigRequest is the body for POST /v1/config/global.
+type SetGlobalConfigRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
 type WhitelistStatusResponse struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`

--- a/internal/control/client.go
+++ b/internal/control/client.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -45,6 +46,24 @@ func (c *Client) get(path string, out any) error {
 
 func (c *Client) post(path string) error {
 	resp, err := c.httpClient.Post("http://jailtimed"+path, "application/json", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var e ErrorResponse
+		_ = json.NewDecoder(resp.Body).Decode(&e)
+		return fmt.Errorf("server error: %s", e.Error)
+	}
+	return nil
+}
+
+func (c *Client) postJSON(path string, body any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Post("http://jailtimed"+path, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
@@ -168,4 +187,18 @@ func (c *Client) StopWhitelist(name string) error {
 // RestartWhitelist calls POST /v1/whitelists/{name}/restart.
 func (c *Client) RestartWhitelist(name string) error {
 	return c.post("/v1/whitelists/" + name + "/restart")
+}
+
+// GlobalConfig calls GET /v1/config/global and returns all engine config fields.
+func (c *Client) GlobalConfig() (*GlobalConfigResponse, error) {
+	var resp GlobalConfigResponse
+	if err := c.get("/v1/config/global", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SetGlobalConfig calls POST /v1/config/global to update a single config field.
+func (c *Client) SetGlobalConfig(key, value string) error {
+	return c.postJSON("/v1/config/global", SetGlobalConfigRequest{Key: key, Value: value})
 }

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -26,6 +26,8 @@ type JailController interface {
 	RestartWhitelist(ctx context.Context, name string) error
 	WhitelistStatus(name string) (string, error)
 	AllWhitelistStatuses() map[string]string
+	GlobalConfig() map[string]string
+	SetGlobalConfig(key, value string) error
 }
 
 // Server serves the control API over a Unix domain socket.
@@ -55,6 +57,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/health", s.handleHealth)
 	mux.HandleFunc("/v1/perf", s.handlePerf)
+	mux.HandleFunc("/v1/config/global", s.handleGlobalConfig)
 	mux.HandleFunc("/v1/jails", s.handleJails)
 	mux.HandleFunc("/v1/jails/", s.handleJailAction)
 	mux.HandleFunc("/v1/whitelists", s.handleWhitelists)
@@ -88,6 +91,34 @@ func (s *Server) handlePerf(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, s.controller.PerfStats())
+}
+
+// handleGlobalConfig handles GET/POST /v1/config/global.
+// GET returns all EngineConfig fields as a key-value map (actions excluded).
+// POST accepts {"key": "...", "value": "..."} and updates the named field.
+func (s *Server) handleGlobalConfig(w http.ResponseWriter, r *http.Request) {
+	slog.Info("control request", "method", r.Method, "path", r.URL.Path)
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, GlobalConfigResponse{Config: s.controller.GlobalConfig()})
+	case http.MethodPost:
+		var req SetGlobalConfigRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "invalid request body: " + err.Error()})
+			return
+		}
+		if req.Key == "" {
+			writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "missing required field: key"})
+			return
+		}
+		if err := s.controller.SetGlobalConfig(req.Key, req.Value); err != nil {
+			writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, HealthResponse{Status: "ok"})
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, ErrorResponse{Error: "method not allowed"})
+	}
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -554,3 +554,71 @@ func (m *Manager) RestartWhitelist(ctx context.Context, name string) error {
 	slog.Info("starting whitelist", "whitelist", name)
 	return targetJr.Start(ctx)
 }
+
+// GlobalConfig returns the current EngineConfig as a string map (excluding actions).
+// All duration values are formatted as Go duration strings.
+func (m *Manager) GlobalConfig() map[string]string {
+	m.mu.RLock()
+	eng := m.cfg.Engine
+	m.mu.RUnlock()
+	return map[string]string{
+		"watcher_mode":   eng.WatcherMode,
+		"poll_interval":  eng.PollInterval.Duration.String(),
+		"read_from_end":  fmt.Sprintf("%t", eng.ReadFromEnd),
+		"target_latency": eng.TargetLatency.Duration.String(),
+		"perf_window":    fmt.Sprintf("%d", eng.PerfWindow),
+	}
+}
+
+// SetGlobalConfig updates a single EngineConfig field by key at runtime.
+// For "target_latency" and "poll_interval" the watch backend and perf metrics
+// are also updated so the change takes effect immediately.
+func (m *Manager) SetGlobalConfig(key, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch key {
+	case "target_latency", "poll_interval":
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("invalid duration %q: %w", value, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("duration must be positive")
+		}
+		if key == "target_latency" {
+			m.cfg.Engine.TargetLatency = config.Duration{Duration: d}
+		} else {
+			m.cfg.Engine.PollInterval = config.Duration{Duration: d}
+		}
+		// Update backend interval and perf metrics without holding m.mu to
+		// avoid deadlock — but we still hold it here since backend.SetInterval
+		// and perf.SetTargetLatency are independently safe.
+		m.backend.SetInterval(d)
+		if key == "target_latency" {
+			m.perf.SetTargetLatency(d)
+		}
+	case "watcher_mode":
+		m.cfg.Engine.WatcherMode = value
+	case "read_from_end":
+		switch value {
+		case "true":
+			m.cfg.Engine.ReadFromEnd = true
+		case "false":
+			m.cfg.Engine.ReadFromEnd = false
+		default:
+			return fmt.Errorf("invalid boolean %q: must be \"true\" or \"false\"", value)
+		}
+	case "perf_window":
+		var n int
+		if _, err := fmt.Sscanf(value, "%d", &n); err != nil || n < 1 {
+			return fmt.Errorf("invalid perf_window %q: must be a positive integer", value)
+		}
+		m.cfg.Engine.PerfWindow = n
+	default:
+		return fmt.Errorf("unknown global config key %q", key)
+	}
+
+	slog.Info("global config updated", "key", key, "value", value)
+	return nil
+}

--- a/internal/engine/perf.go
+++ b/internal/engine/perf.go
@@ -54,6 +54,13 @@ func (p *PerfMetrics) RecordExecution(execTime, latency, sleepTime time.Duration
 	}
 }
 
+// SetTargetLatency updates the target latency displayed in performance snapshots.
+func (p *PerfMetrics) SetTargetLatency(d time.Duration) {
+	p.mu.Lock()
+	p.targetLatency = d
+	p.mu.Unlock()
+}
+
 // Close releases resources held by the PerfMetrics (e.g. the open cgroup fd).
 func (p *PerfMetrics) Close() {
 	_ = p.cpuSampler.Close()

--- a/internal/watch/backend.go
+++ b/internal/watch/backend.go
@@ -63,6 +63,9 @@ type Backend interface {
 	// UpdateSpecs replaces the set of watch specs. New jails are picked up on
 	// the next rescan/poll cycle; removed jails stop generating events.
 	UpdateSpecs(specs []WatchSpec)
+	// SetInterval updates the drain/poll interval at runtime. The change takes
+	// effect on the next tick or drain-timer arm.
+	SetInterval(d time.Duration)
 }
 
 // debugRateLimiter allows at most maxPerSec log entries per second.

--- a/internal/watch/fsnotify.go
+++ b/internal/watch/fsnotify.go
@@ -14,8 +14,8 @@ import (
 // It uses a lazy one-shot drain timer: the timer is only armed when a dirty
 // path is detected, so the goroutine is truly idle when no files change.
 type FsnotifyBackend struct {
-	drainInterval time.Duration
 	mu            sync.RWMutex
+	drainInterval time.Duration
 	specs         []WatchSpec
 }
 
@@ -24,6 +24,20 @@ func NewFsnotifyBackend(drainInterval time.Duration) *FsnotifyBackend {
 }
 
 func (b *FsnotifyBackend) Name() string { return "fsnotify" }
+
+// SetInterval updates the drain interval. The change takes effect when the
+// next drain timer is armed.
+func (b *FsnotifyBackend) SetInterval(d time.Duration) {
+	b.mu.Lock()
+	b.drainInterval = d
+	b.mu.Unlock()
+}
+
+func (b *FsnotifyBackend) getDrainInterval() time.Duration {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.drainInterval
+}
 
 // UpdateSpecs replaces the current watch specs. The change takes effect on
 // the next rescan.
@@ -45,7 +59,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		slog.Info("fsnotify unavailable, falling back to poll", "error", err)
-		return NewPollBackend(b.drainInterval).Start(ctx, b.getSpecs(), drain)
+		return NewPollBackend(b.getDrainInterval()).Start(ctx, b.getSpecs(), drain)
 	}
 	defer watcher.Close()
 	slog.Info("fsnotify backend started")
@@ -132,7 +146,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 		if drainTimerC != nil {
 			return
 		}
-		wait := b.drainInterval - lastDrainTime
+		wait := b.getDrainInterval() - lastDrainTime
 		if wait < time.Millisecond {
 			wait = time.Millisecond
 		}

--- a/internal/watch/poll.go
+++ b/internal/watch/poll.go
@@ -12,8 +12,8 @@ import (
 
 // PollBackend implements Backend by polling the filesystem at a fixed interval.
 type PollBackend struct {
-	interval time.Duration
 	mu       sync.RWMutex
+	interval time.Duration
 	specs    []WatchSpec
 }
 
@@ -22,6 +22,20 @@ func NewPollBackend(interval time.Duration) *PollBackend {
 }
 
 func (b *PollBackend) Name() string { return "poll" }
+
+// SetInterval updates the poll interval. The change takes effect on the next
+// ticker reset inside Start.
+func (b *PollBackend) SetInterval(d time.Duration) {
+	b.mu.Lock()
+	b.interval = d
+	b.mu.Unlock()
+}
+
+func (b *PollBackend) getInterval() time.Duration {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.interval
+}
 
 // UpdateSpecs replaces the current watch specs. The change takes effect on
 // the next poll cycle.
@@ -73,7 +87,8 @@ func (b *PollBackend) Start(ctx context.Context, specs []WatchSpec, drain DrainF
 	tailers := make(map[string]*FileTailer)
 	staticSnapshots := make(map[string]map[string]bool)
 
-	ticker := time.NewTicker(b.interval)
+	currentInterval := b.getInterval()
+	ticker := time.NewTicker(currentInterval)
 	defer ticker.Stop()
 
 	for {
@@ -84,6 +99,10 @@ func (b *PollBackend) Start(ctx context.Context, specs []WatchSpec, drain DrainF
 			}
 			return ctx.Err()
 		case <-ticker.C:
+			if d := b.getInterval(); d != currentInterval {
+				currentInterval = d
+				ticker.Reset(currentInterval)
+			}
 			currentSpecs := b.getSpecs()
 
 			excluded := buildExcludeSet(currentSpecs)


### PR DESCRIPTION
## Summary

Closes #21

Adds API and CLI to read and update global engine configuration at runtime.

## New API

- **GET `/v1/config/global`** — returns all `EngineConfig` fields as a string map (actions excluded)
- **POST `/v1/config/global`** with `{"key": "...", "value": "..."}` — updates a single field live

## New CLI

```
jailtime config global                        # read all global config
jailtime config global target_latency 5s      # set target_latency
jailtime config global perf_window 5          # set perf_window
```

Settable keys: `target_latency`, `poll_interval`, `watcher_mode`, `read_from_end`, `perf_window`.

## Implementation details

- `target_latency` / `poll_interval` changes propagate immediately to the watch backend (new `SetInterval` on `Backend` interface) and perf metrics (`PerfMetrics.SetTargetLatency`).
- `PollBackend` resets its ticker on the next tick when the interval has changed.
- `FsnotifyBackend` uses the new interval on the next drain-timer arm.
- All other keys update the in-memory `EngineConfig` only (effective for new operations that read those fields).