### PR TITLE
refactor: move jail controls under 'jail' subcommand (issue #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ journalctl -u jailtimed -f
 ### Verify
 
 ```sh
-jailtime status
+jailtime jail status
 jailtime config files nginx
 jailtime config test nginx /var/log/nginx/access.log --matching
 ```

--- a/cmd/jailtime/main.go
+++ b/cmd/jailtime/main.go
@@ -28,13 +28,19 @@ func main() {
 		return control.NewClient(socketPath)
 	}
 
-	// ── status ───────────────────────────────────────────────────────────────
-	statusCmd := &cobra.Command{
+	// ── jail ─────────────────────────────────────────────────────────────────
+	jailCmd := &cobra.Command{
+		Use:   "jail",
+		Short: "Manage jails",
+		Long:  "Commands for listing, starting, stopping and restarting jails in a running jailtimed daemon.",
+	}
+
+	jailStatusCmd := &cobra.Command{
 		Use:   "status [jail]",
 		Short: "Show status of all jails, or a specific jail",
 		Long:  "Show the running status of all jails managed by jailtimed.\nPass a jail name to query a single jail.",
-		Example: `  jailtime status
-  jailtime status sshd`,
+		Example: `  jailtime jail status
+  jailtime jail status sshd`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := client()
@@ -59,41 +65,40 @@ func main() {
 		},
 	}
 
-	// ── start ────────────────────────────────────────────────────────────────
-	startCmd := &cobra.Command{
+	jailStartCmd := &cobra.Command{
 		Use:     "start <jail>",
 		Short:   "Start a jail",
-		Example: "  jailtime start sshd",
+		Example: "  jailtime jail start sshd",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return client().StartJail(args[0])
 		},
 	}
 
-	// ── stop ─────────────────────────────────────────────────────────────────
-	stopCmd := &cobra.Command{
+	jailStopCmd := &cobra.Command{
 		Use:     "stop <jail>",
 		Short:   "Stop a jail",
-		Example: "  jailtime stop sshd",
+		Example: "  jailtime jail stop sshd",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return client().StopJail(args[0])
 		},
 	}
 
-	// ── restart ──────────────────────────────────────────────────────────────
-	restartCmd := &cobra.Command{
+	jailRestartCmd := &cobra.Command{
 		Use:   "restart <jail>",
 		Short: "Restart a jail (reloads config from disk)",
 		Long: `Restart a jail. jailtimed reloads its configuration from disk before
 restarting the named jail, picking up any changes to the config file or
 any included fragment files under jails.d/.`,
-		Example: "  jailtime restart sshd",
+		Example: "  jailtime jail restart sshd",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return client().RestartJail(args[0])
 		},
 	}
+
+	jailCmd.AddCommand(jailStatusCmd, jailStartCmd, jailStopCmd, jailRestartCmd)
 
 	// ── version ──────────────────────────────────────────────────────────────
 	versionCmd := &cobra.Command{
@@ -257,7 +262,7 @@ matched. No hit counts are modified and no actions are executed.`,
 	}
 
 	whitelistCmd.AddCommand(whitelistStatusCmd, whitelistStartCmd, whitelistStopCmd, whitelistRestartCmd)
-	root.AddCommand(statusCmd, startCmd, stopCmd, restartCmd, versionCmd, configCmd, perfCmd, whitelistCmd)
+	root.AddCommand(jailCmd, versionCmd, configCmd, perfCmd, whitelistCmd)
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -256,5 +256,5 @@ echo "    1. Copy a sample jail:  cp /usr/share/doc/jailtime/jails.d/a-nginx-dro
 echo "                               /etc/jailtime/jails.d/"
 echo "    2. Edit as needed:      \$EDITOR /etc/jailtime/jails.d/a-nginx-drop.yaml"
 echo "    3. Start the daemon:    systemctl start jailtimed"
-echo "    4. Check status:        jailtime status"
+echo "    4. Check status:        jailtime jail status"
 echo

--- a/docs/jailtime.md
+++ b/docs/jailtime.md
@@ -13,27 +13,27 @@ These flags are available on every command.
 
 ```sh
 # Use a non-default socket
-jailtime --socket /run/custom/jailtime.sock status
+jailtime --socket /run/custom/jailtime.sock jail status
 ```
 
 ---
 
 ## Commands
 
-### `status`
+### `jail status`
 
 Show the running status of all jails, or a single named jail.
 
 ```
-jailtime status [jail]
+jailtime jail status [jail]
 ```
 
 ```sh
 # All jails
-jailtime status
+jailtime jail status
 
 # One jail
-jailtime status sshd
+jailtime jail status sshd
 ```
 
 **Output** (tabular):
@@ -47,46 +47,46 @@ webapp   stopped
 
 ---
 
-### `start`
+### `jail start`
 
 Start a jail. Runs the jail's `on_start` actions.
 
 ```
-jailtime start <jail>
+jailtime jail start <jail>
 ```
 
 ```sh
-jailtime start sshd
+jailtime jail start sshd
 ```
 
 ---
 
-### `stop`
+### `jail stop`
 
 Stop a jail. Runs the jail's `on_stop` actions.
 
 ```
-jailtime stop <jail>
+jailtime jail stop <jail>
 ```
 
 ```sh
-jailtime stop sshd
+jailtime jail stop sshd
 ```
 
 ---
 
-### `restart`
+### `jail restart`
 
 Restart a jail. jailtimed reloads its configuration from disk before restarting,
 so any changes to `jail.yaml` or fragment files under `jails.d/` take effect immediately.
 Also reconciles new or removed jails found in the updated config.
 
 ```
-jailtime restart <jail>
+jailtime jail restart <jail>
 ```
 
 ```sh
-jailtime restart sshd
+jailtime jail restart sshd
 ```
 
 ---

--- a/docs/jailtimed.md
+++ b/docs/jailtimed.md
@@ -246,10 +246,10 @@ is run.
 
 | Hook | When it runs |
 |------|-------------|
-| `on_start` | When the jail starts (daemon startup or `jailtime start`) |
+| `on_start` | When the jail starts (daemon startup or `jailtime jail start`) |
 | `on_match` | When `hit_count` is reached within `find_time`; skipped if `query` exits 0 |
-| `on_stop` | When the jail stops (`jailtime stop` or daemon shutdown) |
-| `on_restart` | When `jailtime restart` is issued (runs after `on_stop`/`on_start` for the named jail) |
+| `on_stop` | When the jail stops (`jailtime jail stop` or daemon shutdown) |
+| `on_restart` | When `jailtime jail restart` is issued (runs after `on_stop`/`on_start` for the named jail) |
 
 `on_match` is **required** — a jail with no `on_match` actions fails validation.
 
@@ -324,5 +324,5 @@ and are installed to `/usr/local/lib/jailtime/` by `deploy/setup.sh`.
 # Use a sample jail
 cp /usr/share/doc/jailtime/jails.d/a-nginx-drop.yaml /etc/jailtime/jails.d/
 $EDITOR /etc/jailtime/jails.d/a-nginx-drop.yaml
-jailtime restart nginx
+jailtime jail restart nginx
 ```


### PR DESCRIPTION
## Summary

Closes #23

Moves the top-level jail control commands under a `jail` subcommand, making the CLI consistent with the existing `whitelist` subcommand structure.

## Before / After

| Before | After |
|--------|-------|
| `jailtime status [jail]` | `jailtime jail status [jail]` |
| `jailtime start <jail>` | `jailtime jail start <jail>` |
| `jailtime stop <jail>` | `jailtime jail stop <jail>` |
| `jailtime restart <jail>` | `jailtime jail restart <jail>` |

## Changes

- `cmd/jailtime/main.go` — commands restructured under `jailCmd` parent, matching `whitelistCmd` pattern
- `docs/jailtime.md` — updated command reference
- `docs/jailtimed.md` — updated `on_start`/`on_stop`/`on_restart` trigger descriptions and example
- `README.md` — updated quick-start verify step
- `deploy/setup.sh` — updated post-install hint