### PR TITLE
fix: use moving average to compute sleep time (fixes #24)

### DIFF
--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -22,9 +22,9 @@ type Manager struct {
 	backend         watch.Backend
 	mu              sync.RWMutex
 	perf            *PerfMetrics
+	targetLatency   time.Duration
 	currentInterval time.Duration
 	lastDrainAt     time.Time
-	lastExecTime    time.Duration
 }
 
 func NewManager(cfg *config.Config, configPath string) (*Manager, error) {
@@ -54,13 +54,19 @@ func NewManager(cfg *config.Config, configPath string) (*Manager, error) {
 	}
 	backend := watch.NewAuto(cfg.Engine.WatcherMode, targetLatency)
 
+	perfWindow := cfg.Engine.PerfWindow
+	if perfWindow < 1 {
+		perfWindow = 1
+	}
+
 	m := &Manager{
 		cfg:             cfg,
 		configPath:      configPath,
 		jails:           jails,
 		whitelists:      whitelists,
 		backend:         backend,
-		perf:            NewPerfMetrics(targetLatency, "jailtimed.service"),
+		perf:            NewPerfMetrics(targetLatency, perfWindow, "jailtimed.service"),
+		targetLatency:   targetLatency,
 		currentInterval: targetLatency,
 	}
 	m.injectIgnoreSets()
@@ -143,14 +149,15 @@ func (m *Manager) processDrain(ctx context.Context, lines []watch.RawLine) {
 	}
 	m.lastDrainAt = drainStart
 
-	// Sleep time = interval since last drain minus the previous drain's execution time.
-	sleepTime := m.currentInterval - m.lastExecTime
+	// Intended sleep steers towards targetLatency using the moving average of
+	// previous execution times: sleep = targetLatency - movingAvgExec.
+	// This ensures sleep is always <= targetLatency regardless of OS scheduling drift.
+	intendedSleep := m.perf.IntendedSleep()
 
 	m.processBatch(ctx, lines)
 
 	execTime := time.Since(drainStart)
-	m.perf.RecordExecution(execTime, m.currentInterval, sleepTime, len(lines))
-	m.lastExecTime = execTime
+	m.perf.RecordExecution(execTime, m.currentInterval, intendedSleep, len(lines))
 }
 
 func (m *Manager) processBatch(ctx context.Context, lines []watch.RawLine) {

--- a/internal/engine/manager_test.go
+++ b/internal/engine/manager_test.go
@@ -82,7 +82,7 @@ func TestGlobalOnStartRunsBeforeJails(t *testing.T) {
 		jails:      map[string]*JailRuntime{"alpha": jr},
 		whitelists: map[string]*JailRuntime{},
 		backend:    watch.NewAuto("poll", 50*time.Millisecond),
-		perf:       NewPerfMetrics(50*time.Millisecond, ""),
+		perf:       NewPerfMetrics(50*time.Millisecond, 1, ""),
 	}
 	m.currentInterval = 50 * time.Millisecond
 
@@ -146,7 +146,7 @@ func TestJailsStartInAlphabeticalOrder(t *testing.T) {
 		jails:      jails,
 		whitelists: map[string]*JailRuntime{},
 		backend:    watch.NewAuto("poll", 50*time.Millisecond),
-		perf:       NewPerfMetrics(50*time.Millisecond, ""),
+		perf:       NewPerfMetrics(50*time.Millisecond, 1, ""),
 	}
 	m.currentInterval = 50 * time.Millisecond
 
@@ -173,7 +173,7 @@ func TestJailsStartInAlphabeticalOrder(t *testing.T) {
 // as the elapsed time between successive drain calls.
 func TestManagerCurrentInterval(t *testing.T) {
 	m := &Manager{
-		perf: NewPerfMetrics(3, ""),
+		perf: NewPerfMetrics(3, 1, ""),
 	}
 
 	ctx := context.Background()

--- a/internal/engine/perf.go
+++ b/internal/engine/perf.go
@@ -21,24 +21,33 @@ type PerfMetrics struct {
 
 	targetLatency time.Duration
 
-	lastLatency   time.Duration
-	lastExec      time.Duration
-	lastSleep     time.Duration
-	lastLines     int
+	lastLatency time.Duration
+	lastExec    time.Duration
+	lastSleep   time.Duration
+	lastLines   int
+
+	// execWindow is a ring buffer holding the last perfWindow execution times.
+	execWindow []time.Duration
+	windowIdx  int
+	windowFull bool
 
 	cpuSampler *cgroupCPUSampler
 	lastCPU    float64
 }
 
-func NewPerfMetrics(targetLatency time.Duration, serviceName string) *PerfMetrics {
+func NewPerfMetrics(targetLatency time.Duration, perfWindow int, serviceName string) *PerfMetrics {
+	if perfWindow < 1 {
+		perfWindow = 1
+	}
 	return &PerfMetrics{
 		targetLatency: targetLatency,
+		execWindow:    make([]time.Duration, perfWindow),
 		cpuSampler:    newCgroupCPUSampler(serviceName),
 	}
 }
 
 // RecordExecution is called after each batch drain.
-// sleepTime is the duration the backend slept before this drain.
+// sleepTime is the intended sleep before the next drain.
 // batchSize 0 means no lines were processed; CPU is not sampled in that case.
 func (p *PerfMetrics) RecordExecution(execTime, latency, sleepTime time.Duration, batchSize int) {
 	p.mu.Lock()
@@ -48,6 +57,14 @@ func (p *PerfMetrics) RecordExecution(execTime, latency, sleepTime time.Duration
 	p.lastLatency = latency
 	p.lastSleep = sleepTime
 	p.lastLines = batchSize
+
+	// Update the ring buffer with the latest execution time.
+	p.execWindow[p.windowIdx] = execTime
+	p.windowIdx++
+	if p.windowIdx >= len(p.execWindow) {
+		p.windowIdx = 0
+		p.windowFull = true
+	}
 
 	if batchSize > 0 {
 		p.lastCPU = p.cpuSampler.Sample()
@@ -59,6 +76,52 @@ func (p *PerfMetrics) SetTargetLatency(d time.Duration) {
 	p.mu.Lock()
 	p.targetLatency = d
 	p.mu.Unlock()
+}
+
+// MovingAvgExec returns the moving average of execution times over the window.
+// Must be called without p.mu held.
+func (p *PerfMetrics) MovingAvgExec() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.movingAvgExecLocked()
+}
+
+// movingAvgExecLocked returns the moving average of execution times.
+// Must be called with p.mu held (at least RLock).
+func (p *PerfMetrics) movingAvgExecLocked() time.Duration {
+	n := len(p.execWindow)
+	if n == 0 {
+		return 0
+	}
+	count := n
+	if !p.windowFull {
+		count = p.windowIdx
+	}
+	if count == 0 {
+		return 0
+	}
+	var total time.Duration
+	for _, d := range p.execWindow {
+		total += d
+	}
+	return total / time.Duration(n)
+}
+
+// IntendedSleep returns the sleep duration that steers total cycle time
+// towards targetLatency: targetLatency minus the moving-average execution
+// time, clamped to [0, targetLatency].
+func (p *PerfMetrics) IntendedSleep() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	sleep := p.targetLatency - p.movingAvgExecLocked()
+	if sleep < 0 {
+		return 0
+	}
+	if sleep > p.targetLatency {
+		return p.targetLatency
+	}
+	return sleep
 }
 
 // Close releases resources held by the PerfMetrics (e.g. the open cgroup fd).

--- a/internal/engine/perf_test.go
+++ b/internal/engine/perf_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPerfMetrics_SnapshotLastValues(t *testing.T) {
-	p := NewPerfMetrics(2*time.Second, "nonexistent-service-for-test.service")
+	p := NewPerfMetrics(2*time.Second, 3, "nonexistent-service-for-test.service")
 
 	p.RecordExecution(10*time.Millisecond, 100*time.Millisecond, 90*time.Millisecond, 5)
 	p.RecordExecution(30*time.Millisecond, 120*time.Millisecond, 95*time.Millisecond, 8)
@@ -31,7 +31,7 @@ func TestPerfMetrics_SnapshotLastValues(t *testing.T) {
 }
 
 func TestPerfMetrics_ZeroBeforeFirstRecord(t *testing.T) {
-	p := NewPerfMetrics(2*time.Second, "nonexistent-service-for-test.service")
+	p := NewPerfMetrics(2*time.Second, 3, "nonexistent-service-for-test.service")
 	snap := p.Snapshot()
 
 	if snap.ExecutionMs != 0 {
@@ -47,10 +47,59 @@ func TestPerfMetrics_ZeroBeforeFirstRecord(t *testing.T) {
 
 func TestPerfMetrics_UnavailableCgroupNoPanic(t *testing.T) {
 	// Must not panic even when cgroup path doesn't exist.
-	p := NewPerfMetrics(2*time.Second, "no-such-service-xyz-123.service")
+	p := NewPerfMetrics(2*time.Second, 3, "no-such-service-xyz-123.service")
 	p.RecordExecution(1*time.Millisecond, 10*time.Millisecond, 9*time.Millisecond, 1)
 	snap := p.Snapshot()
 	if snap.TargetLatencyMs != 2000.0 {
 		t.Errorf("TargetLatencyMs = %v, want 2000.0", snap.TargetLatencyMs)
+	}
+}
+
+// TestPerfMetrics_IntendedSleepNeverExceedsTarget verifies that IntendedSleep
+// is always <= targetLatency, even when execution time is zero.
+func TestPerfMetrics_IntendedSleepNeverExceedsTarget(t *testing.T) {
+	target := 2 * time.Second
+	p := NewPerfMetrics(target, 3, "nonexistent-service-for-test.service")
+
+	// Before any recording, sleep should equal targetLatency (avg exec = 0).
+	sleep := p.IntendedSleep()
+	if sleep > target {
+		t.Errorf("IntendedSleep = %v, want <= %v before any record", sleep, target)
+	}
+	if sleep != target {
+		t.Errorf("IntendedSleep = %v, want %v when no exec recorded", sleep, target)
+	}
+
+	// After recording a fast execution, sleep should be slightly below target.
+	p.RecordExecution(10*time.Millisecond, target, target-10*time.Millisecond, 5)
+	sleep = p.IntendedSleep()
+	if sleep > target {
+		t.Errorf("IntendedSleep = %v exceeds targetLatency %v", sleep, target)
+	}
+
+	// After recording a slow execution (larger than target), sleep should be 0.
+	p2 := NewPerfMetrics(50*time.Millisecond, 1, "nonexistent-service-for-test.service")
+	p2.RecordExecution(100*time.Millisecond, 100*time.Millisecond, 0, 1)
+	sleep2 := p2.IntendedSleep()
+	if sleep2 != 0 {
+		t.Errorf("IntendedSleep = %v, want 0 when exec > target", sleep2)
+	}
+}
+
+// TestPerfMetrics_MovingAvgWindow verifies that the ring buffer averages over
+// the last perfWindow samples.
+func TestPerfMetrics_MovingAvgWindow(t *testing.T) {
+	// Window size 3; record 4 values: 10, 20, 30, 40ms. After 4 records the
+	// ring buffer holds [40, 20, 30] (oldest entry overwritten), avg = 30ms.
+	p := NewPerfMetrics(2*time.Second, 3, "nonexistent-service-for-test.service")
+	for _, d := range []time.Duration{10, 20, 30, 40} {
+		p.RecordExecution(d*time.Millisecond, 2*time.Second, 0, 1)
+	}
+
+	avg := p.MovingAvgExec()
+	// Window contains [40, 20, 30] → average = 90/3 = 30ms.
+	want := 30 * time.Millisecond
+	if avg != want {
+		t.Errorf("MovingAvgExec = %v, want %v", avg, want)
 	}
 }


### PR DESCRIPTION
## Problem

The `jailtime perf` output showed sleep times exceeding `targetLatency` due to OS scheduling jitter. `processDrain` computed `sleepTime = currentInterval - lastExecTime`, where `currentInterval` is the raw wall-clock gap between drains and can exceed `targetLatency`.

Example (issue #24):
```
Target Latency: 2000ms
Latency:   2550ms
Sleep:     2550ms   ← should never exceed 2000ms
```

## Solution

- Added an **exec-time ring buffer** (size = `engine.perf_window`, default 3) to `PerfMetrics`, tracking the last N execution times.
- Added `MovingAvgExec()` and `IntendedSleep()` methods. `IntendedSleep() = targetLatency - movingAvgExec`, clamped to `[0, targetLatency]`.
- `processDrain` now records the **intended sleep** (derived from the moving average) rather than the observed interval, so the displayed sleep steers toward `targetLatency` and is always `<= targetLatency`.
- `NewPerfMetrics` gains a `perfWindow int` parameter, wired from `cfg.Engine.PerfWindow` in `Manager`.

## Tests

- Updated existing perf tests for new `NewPerfMetrics` signature.
- Added `TestPerfMetrics_IntendedSleepNeverExceedsTarget`: verifies sleep ≤ targetLatency in all cases.
- Added `TestPerfMetrics_MovingAvgWindow`: verifies the ring buffer correctly averages over the last `perfWindow` samples.

Closes #24