### PR TITLE
docs: update README and docs to reflect current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # jailtime
 
-A fail2ban-style intrusion-prevention daemon written in Go. `jailtime` watches log files for patterns, tracks hit counts within a configurable time window, and executes shell actions (e.g. firewall rules) when a threshold is exceeded.
+```
+ | | |         _  _    _
+ | | |        (_)| |  (_)
+ | | |  __ _   _ | |_  _  _ __ ___    ___
+ | | | / _` | | || __|| || '_ ` _ \  / _ \
+ | | || (_| | | || |_ | || | | | | ||  __/
+ |_|_| \__,_| |_| \__||_||_| |_| |_| \___|
+ | | |
+```
+
+A fail2ban-style intrusion-prevention daemon written in Go. `jailtimed` watches
+log files for patterns, tracks hit counts within a sliding time window, and
+executes shell actions (e.g. firewall rules) when a threshold is exceeded.
+It uses an event-driven architecture with a lazy drain timer — truly idle when
+no log activity occurs.
 
 ## Documentation
 
@@ -10,38 +24,65 @@ A fail2ban-style intrusion-prevention daemon written in Go. `jailtime` watches l
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────┐
-│                  jailtimed                  │
-│                                             │
-│  ┌──────────┐   events   ┌───────────────┐  │
-│  │  Watch   │──────────▶ │ Engine/Manager│  │
-│  │ Backend  │            │  JailRuntime  │  │
-│  └──────────┘            │  HitTracker   │  │
-│                          └───────────────┘  │
-│                                             │
-│  ┌──────────────────────────────────────┐   │
-│  │  Control Server (Unix socket HTTP)   │   │
-│  └──────────────────────────────────────┘   │
-└─────────────────────────────────────────────┘
+  fsnotify / inotify kernel events
+         │
+         ▼
+  ┌──────────────────────────────────────────────────────┐
+  │  FsnotifyBackend  (single goroutine, one select loop) │
+  │                                                       │
+  │  WRITE → mark dirty → arm one-shot drain timer        │
+  │  CREATE → discover new files matching globs           │
+  │  timer fires → collect lines → processDrain()         │
+  │  idle → timer nil, zero wakeups                       │
+  └──────────────┬───────────────────────────────────────┘
+                 │ DrainFunc (called synchronously)
+                 ▼
+  ┌──────────────────────────────────────────────────────┐
+  │  Manager / Engine                                     │
+  │                                                       │
+  │  processDrain(lines []RawLine)                        │
+  │    └─ for each line:                                  │
+  │         ├─ JailRuntime.HandleEvent()                  │
+  │         │    ├─ filter.Match (include/exclude regex)  │
+  │         │    ├─ whitelist ignore_sets check           │
+  │         │    └─ HitTracker.Record (sliding window)    │
+  │         │         └─ threshold hit →                  │
+  │         │              ActionRunner.Submit(ip, fn)    │
+  │         └─ perf.RecordExecution(execTime, interval)   │
+  └──────────────────────────────────────────────────────┘
          ▲
-         │ jailtime CLI
+         │  HTTP over Unix socket (/run/jailtime/jailtimed.sock)
+         ▼
+  ┌─────────────────────────────────┐
+  │  Control Server  (HTTP mux)     │
+  │  /v1/health                     │
+  │  /v1/jails[/{name}/…]           │
+  │  /v1/whitelists[/{name}/…]      │
+  │  /v1/perf                       │
+  │  /v1/config/global              │
+  └────────────┬────────────────────┘
+               │
+        jailtime CLI
 ```
 
 | Component | Description |
 |-----------|-------------|
-| **Watch Backend** | Watches log files via fsnotify or polling; re-expands globs each tick |
-| **Engine/Manager** | Manages jail lifecycles; routes file events to JailRuntimes |
-| **JailRuntime** | Compiles filters, tracks hits per IP, runs shell actions |
-| **HitTracker** | Sliding-window counter per IP address |
-| **Control Server** | HTTP-over-Unix-socket API for runtime control |
-| **jailtime CLI** | Client for the control socket |
+| **FsnotifyBackend** | Event-driven log watching via inotify/fsnotify. Lazy one-shot drain timer — zero wakeups when idle. Re-expands globs on each CREATE event to pick up new files without restart. |
+| **PollBackend** | Polling fallback (or explicit `watcher_mode: poll`). Re-expands globs each tick. |
+| **Manager** | Owns all JailRuntimes. Receives `[]RawLine` batches synchronously from the backend via `processDrain`. No internal goroutine or timer. |
+| **JailRuntime** | Compiles include/exclude filter regexes. Routes `RawLine` events to `HitTracker` and `ActionRunner`. Supports `watch_mode: tail` (log files) and `watch_mode: static` (IP/CIDR list files). |
+| **HitTracker** | Sliding-window hit counter per IP/CIDR. |
+| **ActionRunner** | Executes `on_add` shell actions asynchronously per IP. Drops duplicate in-flight actions for the same IP. |
+| **Whitelists** | Special jail entries using `watch_mode: static` that maintain an in-memory IP/CIDR set. Jails reference them via `ignore_sets` to suppress `on_add` for known-safe addresses. |
+| **Control Server** | HTTP-over-Unix-socket API. Handles jail/whitelist lifecycle, config inspection, perf metrics, and runtime config updates. |
+| **jailtime CLI** | Client for the control socket (`jail`, `whitelist`, `config`, `perf`, `version` commands). |
 
 ## Quick start
 
 ### Build
 
 ```sh
-git clone https://github.com/sgw/jailtime
+git clone https://github.com/saygoweb/jailtime
 cd jailtime
 go build -o jailtimed ./cmd/jailtimed
 go build -o jailtime  ./cmd/jailtime
@@ -81,7 +122,97 @@ journalctl -u jailtimed -f
 ### Verify
 
 ```sh
+# Jail and whitelist status
 jailtime jail status
+jailtime whitelist status
+
+# Inspect matched log files and test filters
 jailtime config files nginx
 jailtime config test nginx /var/log/nginx/access.log --matching
+
+# Performance metrics
+jailtime perf
+
+# Live runtime config (no restart needed)
+jailtime config global
+jailtime config global target_latency 5s
 ```
+
+## Configuration overview
+
+```yaml
+version: 1
+
+include:
+  - jails.d/*.yaml          # merge fragment files
+
+logging:
+  target: journal           # or "file"
+  level: info
+
+control:
+  socket: /run/jailtime/jailtimed.sock
+
+engine:
+  watcher_mode: auto        # auto | fsnotify | poll
+  target_latency: 2s        # drain timer interval
+  read_from_end: true       # skip history on startup
+  perf_window: 3            # cycles for perf averaging
+
+actions:                    # global daemon lifecycle hooks
+  on_start:
+    - 'logger -t jailtime "daemon started"'
+  on_stop:
+    - 'logger -t jailtime "daemon stopped"'
+
+jails:
+  - name: nginx
+    files:
+      - /var/log/nginx/*/access.log
+    exclude_files:
+      - /var/log/nginx/internal/access.log
+    filters:
+      - '^(?P<ip>[0-9]{1,3}(?:\.[0-9]{1,3}){3}) .* " [45][0-9][0-9] '
+    exclude_filters:
+      - '" [23][0-9][0-9] '
+    hit_count: 10
+    find_time: 1m
+    jail_time: 1h
+    net_type: IP
+    query_before_match: true
+    query: 'ipset test jt_nginx {{ .IP }} 2>/dev/null'
+    action_timeout: 30s
+    actions:
+      on_start:
+        - 'ipset create jt_nginx hash:ip timeout 0 -exist'
+      on_add:
+        - 'ipset add jt_nginx {{ .IP }} timeout {{ .JailTime }} -exist'
+      on_stop:
+        - 'ipset destroy jt_nginx'
+
+whitelists:
+  - name: trusted
+    watch_mode: static
+    files:
+      - /etc/jailtime/trusted.txt
+    net_type: CIDR
+    actions:
+      on_add:
+        - 'logger -t jailtime "trusted {{ .IP }} added"'
+      on_remove:
+        - 'logger -t jailtime "trusted {{ .IP }} removed"'
+```
+
+See [jailtimed configuration](docs/jailtimed.md) for the complete field reference.
+
+## Sample jails
+
+Ready-to-use configurations in `samples/jails.d/`:
+
+| File | Scenario |
+|------|---------|
+| `a-nginx-drop.yaml` | Nginx — iptables DROP via ipset |
+| `b-webapp-reroute.yaml` | Web app — redirect attackers to a honeypot |
+| `c-nginx-drop-idempotent.yaml` | Nginx — idempotent DROP using wrapper scripts |
+| `d-nginx-drop-cidr.yaml` | Nginx — ban entire CIDR blocks, survives reboot |
+| `e-apache-wordpress.yaml` | Apache — WordPress login and xmlrpc brute-force |

--- a/docs/jailtime.md
+++ b/docs/jailtime.md
@@ -187,3 +187,128 @@ Matching lines: 37
 > **Note:** The file path is resolved on the daemon's host filesystem.
 > When running jailtimed in a container or remote host, the path must be
 > accessible to the daemon process, not the jailtime client.
+
+---
+
+### `config global`
+
+Read or update global engine configuration at runtime without restarting the daemon.
+
+```
+jailtime config global [<key> <value>]
+```
+
+Without arguments, lists all current global engine config values. With `<key>` and
+`<value>`, updates the named field immediately.
+
+**Settable keys:** `target_latency`, `poll_interval`, `watcher_mode`, `read_from_end`, `perf_window`
+
+```sh
+# Show current global config
+jailtime config global
+
+# Change the drain timer interval
+jailtime config global target_latency 5s
+
+# Increase the perf rolling-average window
+jailtime config global perf_window 5
+```
+
+**Output (no args):**
+
+```
+target_latency  2s
+poll_interval   2s
+watcher_mode    auto
+read_from_end   true
+perf_window     3
+```
+
+---
+
+### `perf`
+
+Show daemon performance metrics.
+
+```
+jailtime perf
+```
+
+```sh
+jailtime perf
+```
+
+**Output:**
+
+```
+target_latency_ms   2000.0
+latency_ms          2001.3
+execution_ms        0.4
+sleep_ms            1999.6
+lines_processed     142
+cpu_percent         0.1
+```
+
+| Field | Description |
+|-------|-------------|
+| `target_latency_ms` | Configured drain interval target |
+| `latency_ms` | Measured inter-drain interval (rolling average) |
+| `execution_ms` | Time spent processing lines per drain (rolling average) |
+| `sleep_ms` | Idle time between drains (rolling average) |
+| `lines_processed` | Lines processed in the last drain cycle |
+| `cpu_percent` | Estimated daemon CPU usage |
+
+---
+
+### `whitelist status`
+
+Show the running status of all whitelists, or a single named whitelist.
+
+```
+jailtime whitelist status [whitelist]
+```
+
+```sh
+# All whitelists
+jailtime whitelist status
+
+# One whitelist
+jailtime whitelist status trusted
+```
+
+**Output** (tabular):
+
+```
+NAME     STATUS
+trusted  started
+```
+
+---
+
+### `whitelist start`
+
+Start a whitelist. Reads the static file(s) and runs `on_add` actions for each entry.
+
+```
+jailtime whitelist start <whitelist>
+```
+
+---
+
+### `whitelist stop`
+
+Stop a whitelist. Runs `on_remove` actions for each entry currently in the set.
+
+```
+jailtime whitelist stop <whitelist>
+```
+
+---
+
+### `whitelist restart`
+
+Restart a whitelist. Reloads the config and static file(s) from disk.
+
+```
+jailtime whitelist restart <whitelist>
+```

--- a/docs/jailtimed.md
+++ b/docs/jailtimed.md
@@ -1,8 +1,10 @@
 # jailtimed Configuration Reference
 
 `jailtimed` is a fail2ban-style intrusion-prevention daemon. It watches log files
-for patterns, tracks hit counts within a configurable time window, and executes
-shell actions (e.g. firewall rules) when a threshold is exceeded.
+for patterns, tracks hit counts within a sliding time window, and executes shell
+actions (e.g. firewall rules) when a threshold is exceeded. It also supports
+static IP/CIDR allow-list files (whitelists) that are kept in memory and can
+suppress `on_add` actions automatically.
 
 For daemon installation and the `jailtime` CLI, see:
 - [jailtime CLI](jailtime.md)
@@ -39,11 +41,20 @@ control:
 
 engine:
   watcher_mode: auto
-  poll_interval: 2s
+  target_latency: 2s
   read_from_end: true
+  perf_window: 3
+
+actions:            # optional daemon-level lifecycle hooks
+  on_start: []
+  on_stop: []
 
 jails:
   - name: sshd
+    # ...
+
+whitelists:         # optional static IP/CIDR set watchers
+  - name: trusted
     # ...
 ```
 
@@ -72,13 +83,41 @@ jails:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `watcher_mode` | string | `auto` | File watching backend: `auto`, `fsnotify`, or `poll` |
-| `poll_interval` | duration | `2s` | How often to poll for new log lines or new glob matches |
+| `watcher_mode` | string | `auto` | File watching backend: `auto`, `fsnotify`, `inotify`, `os`, or `poll` |
+| `poll_interval` | duration | `2s` | Polling interval when `watcher_mode: poll` |
+| `target_latency` | duration | `2s` | Target drain interval for event-driven mode; controls how quickly log lines are processed |
 | `read_from_end` | bool | `true` | Start reading existing log files from EOF (ignore history) |
+| `perf_window` | int | `3` | Number of drain cycles used for rolling performance averages |
 
-**`watcher_mode`:** `auto` tries fsnotify first and falls back to poll if unavailable.
-Both modes re-evaluate glob patterns on every tick, so files in new subdirectories
-are discovered automatically without a restart.
+**`watcher_mode`:** `auto` tries fsnotify/inotify first and falls back to poll if
+unavailable. `inotify` and `os` are aliases for `fsnotify`. In event-driven mode,
+the drain timer is only armed when a file is written to — zero wakeups when idle.
+Both modes re-evaluate glob patterns on each tick/event, so new files in
+subdirectories are discovered automatically without a restart.
+
+Some engine fields can be updated at runtime without restarting the daemon:
+
+```sh
+jailtime config global target_latency 5s
+jailtime config global perf_window 5
+```
+
+---
+
+## `actions` — global daemon hooks
+
+Global actions run at daemon startup and shutdown, before any jail is started /
+after all jails have stopped. They use the same template syntax as jail actions
+but only `{{ .Jail }}` is available (it is empty for global actions).
+
+```yaml
+actions:
+  on_start:
+    - 'ipset create jt_global hash:ip -exist'
+    - 'logger -t jailtime "daemon started"'
+  on_stop:
+    - 'logger -t jailtime "daemon stopped"'
+```
 
 ---
 
@@ -101,16 +140,17 @@ Fractional values are supported: `1.5h`, `0.5d`.
 ## Fragment files (`include`)
 
 The `include` key takes a list of glob patterns. Each matching file is loaded
-and its `jails:` list is merged into the main config. This lets you keep each
-jail in its own file under `jails.d/`.
+and its `jails:` and/or `whitelists:` lists are merged into the main config.
+This lets you keep each jail or whitelist in its own file under `jails.d/`.
 
 ```yaml
 include:
   - jails.d/*.yaml
 ```
 
-Fragment files may **only** contain a `jails:` key. All other top-level settings
-(`logging`, `engine`, `control`, etc.) must be in the main config file.
+Fragment files may **only** contain `jails:` and/or `whitelists:` keys. All other
+top-level settings (`logging`, `engine`, `control`, `actions`, etc.) must be in
+the main config file.
 
 Relative patterns are resolved relative to the directory containing the main
 config file. The main config file itself is never re-included.
@@ -122,7 +162,8 @@ config file. The main config file itself is never re-included.
 └── jails.d/
     ├── sshd.yaml
     ├── nginx.yaml
-    └── apache2.yaml
+    ├── apache2.yaml
+    └── trusted.yaml   # a whitelist fragment
 ```
 
 ---
@@ -137,6 +178,8 @@ jails:
     enabled: true
     files:
       - /var/log/auth.log
+    exclude_files:
+      - /var/log/auth.log.1
     filters:
       - 'Failed password for .* from (?P<ip>[0-9.]+) port'
     exclude_filters:
@@ -145,14 +188,16 @@ jails:
     find_time: 10m
     jail_time: 1h
     net_type: IP
+    query_before_match: true
     query: 'ipset test jt_{{ .Jail }} {{ .IP }} 2>/dev/null'
+    action_timeout: 30s
     actions:
       on_start:
-        - 'logger -t jailtime "jail {{ .Jail }} started"'
-      on_match:
-        - 'nft add element inet filter blocklist { {{ .IP }} }'
+        - 'ipset create jt_{{ .Jail }} hash:ip timeout 0 -exist'
+      on_add:
+        - 'ipset add jt_{{ .Jail }} {{ .IP }} timeout {{ .JailTime }} -exist'
       on_stop:
-        - 'logger -t jailtime "jail {{ .Jail }} stopped"'
+        - 'ipset destroy jt_{{ .Jail }}'
       on_restart: []
 ```
 
@@ -163,13 +208,17 @@ jails:
 | `name` | string | — | **Required.** Unique jail name |
 | `enabled` | bool | `true` | Set to `false` to disable without removing the config |
 | `files` | []string | — | **Required.** Glob patterns for log files to watch |
-| `filters` | []string | — | **Required.** Include regex patterns (see below) |
+| `exclude_files` | []string | — | Glob patterns to exclude from `files` matches |
+| `filters` | []string | — | Include regex patterns; **required** for `watch_mode: tail` (see below) |
 | `exclude_filters` | []string | — | Exclude regex patterns — a match suppresses the event |
 | `hit_count` | int | `1` | Number of matches within `find_time` before actions fire |
 | `find_time` | duration | — | **Required.** Sliding window for hit counting |
 | `jail_time` | duration | — | **Required.** Ban duration, passed as `{{ .JailTime }}` in seconds to actions |
-| `net_type` | string | `IP` | `IP` — validate capture as a plain IP; `CIDR` — validate as a CIDR block |
-| `query` | string | — | Pre-check command; if it exits **0** (already blocked), `on_match` is skipped |
+| `net_type` | string | `IP` | `IP` — validate as a plain IP; `CIDR` — validate as a CIDR block |
+| `watch_mode` | string | `tail` | `tail` — watch log files for new lines; `static` — watch a file of IP/CIDR entries (see Whitelists) |
+| `query` | string | — | Pre-check command; see `query_before_match` |
+| `query_before_match` | bool | `false` | When `true`, run `query` before `on_add`; if `query` exits **0**, `on_add` is skipped |
+| `action_timeout` | duration | `30s` | Maximum time allowed for each individual action command |
 | `actions` | object | — | Shell commands for lifecycle events (see below) |
 
 ### `files` — glob patterns
@@ -188,6 +237,18 @@ Globs are re-expanded on every watch tick, so files created in new
 subdirectories after the daemon starts are picked up automatically.
 
 Use `jailtime config files <jail>` to inspect which files currently match.
+
+### `exclude_files` — file exclusions
+
+`exclude_files` takes the same glob syntax as `files`. Any path that matches
+an exclude glob is ignored, even if it also matches a `files` glob.
+
+```yaml
+files:
+  - /var/log/apache2/*/access.log
+exclude_files:
+  - /var/log/apache2/internal/access.log
+```
 
 ### `filters` — include patterns
 
@@ -213,24 +274,23 @@ against real log data.
 ### `exclude_filters` — suppress patterns
 
 If any exclude filter matches a line, that line is ignored even if an include
-filter also matched. Useful for whitelisting known-good sources or response
-codes.
+filter also matched. Useful for suppressing known-good sources or response codes.
 
 ```yaml
 exclude_filters:
   - '" [23][0-9][0-9] '      # ignore 2xx/3xx responses
   - 'from 192\.168\.'        # ignore RFC-1918 sources
-  - 'whitelist'
 ```
 
 ### `query` — pre-check
 
-When `query` is set, jailtimed runs it as a shell command before executing
-`on_match` actions. If the command exits **0**, the IP is considered already
-blocked and `on_match` is skipped. Any non-zero exit code (including errors)
-means "not yet blocked — proceed".
+When `query_before_match: true` and `query` is set, jailtimed runs the query as
+a shell command before executing `on_add` actions. If the command exits **0**,
+the IP is considered already blocked and `on_add` is skipped. Any non-zero exit
+code (including errors) means "not yet blocked — proceed".
 
 ```yaml
+query_before_match: true
 query: 'ipset test jt_{{ .Jail }} {{ .IP }} 2>/dev/null'
 ```
 
@@ -240,18 +300,20 @@ query: 'ipset test jt_{{ .Jail }} {{ .IP }} 2>/dev/null'
 
 Actions are lists of shell command strings, executed in order. Each string is
 a Go `text/template` — template variables are substituted before the command
-is run.
+is run. Each action command runs under `/bin/sh -c`.
 
 ### Action hooks
 
 | Hook | When it runs |
 |------|-------------|
 | `on_start` | When the jail starts (daemon startup or `jailtime jail start`) |
-| `on_match` | When `hit_count` is reached within `find_time`; skipped if `query` exits 0 |
+| `on_add` | When `hit_count` is reached within `find_time`; skipped if `query` exits 0 (when `query_before_match: true`) |
+| `on_remove` | When an entry is removed from a `watch_mode: static` file |
 | `on_stop` | When the jail stops (`jailtime jail stop` or daemon shutdown) |
 | `on_restart` | When `jailtime jail restart` is issued (runs after `on_stop`/`on_start` for the named jail) |
 
-`on_match` is **required** — a jail with no `on_match` actions fails validation.
+`on_add` is **required** for `watch_mode: tail` jails — a jail with no `on_add`
+actions fails validation. (`on_match` is accepted as a deprecated alias for `on_add`.)
 
 ### Template variables
 
@@ -268,15 +330,41 @@ is run.
 
 ---
 
+## Whitelists
+
+Whitelists are entries under the top-level `whitelists:` key. They use the same
+`JailConfig` structure as jails but with `watch_mode: static`. jailtimed reads
+the listed files (one IP or CIDR per line) and maintains an in-memory set. When
+a line is added to or removed from the file, `on_add` / `on_remove` actions fire.
+
+```yaml
+whitelists:
+  - name: trusted
+    watch_mode: static
+    files:
+      - /etc/jailtime/trusted.txt
+    net_type: CIDR
+    action_timeout: 10s
+    actions:
+      on_add:
+        - 'logger -t jailtime "trusted CIDR {{ .IP }} loaded"'
+      on_remove:
+        - 'logger -t jailtime "trusted CIDR {{ .IP }} removed"'
+```
+
+Manage whitelists at runtime using `jailtime whitelist status|start|stop|restart`.
+
+---
+
 ## Validation rules
 
 jailtimed validates the config at startup and on every `restart`. Errors are
 reported with the jail name and field:
 
-- `name` must be non-empty and unique across all jails (including merged fragments)
+- `name` must be non-empty and unique across all jails and whitelists (including merged fragments)
 - `files` must contain at least one entry
-- `filters` must contain at least one entry
-- `actions.on_match` must contain at least one entry
+- `filters` must contain at least one entry (for `watch_mode: tail` jails)
+- `actions.on_add` (or `actions.on_match`) must contain at least one entry for `watch_mode: tail` jails
 - `find_time` must be > 0
 - `jail_time` must be > 0
 - `hit_count` must be ≥ 1


### PR DESCRIPTION
Updates README.md, docs/jailtimed.md, and docs/jailtime.md to accurately reflect the current codebase.

## README
- ASCII art banner
- Rewritten architecture section with detailed event-driven drain loop diagram
- Updated component table covering ActionRunner, Whitelists, and FsnotifyBackend lazy timer behaviour
- Configuration overview showing global actions, whitelists, and key new jail fields
- Updated quick-start verify examples (`whitelist`, `perf`, `config global`)

## docs/jailtimed.md
- Global daemon `actions` (on_start/on_stop)
- New `whitelists:` top-level section with `watch_mode: static`, `on_add`/`on_remove`
- Updated `engine` table: `target_latency`, `perf_window`, watcher_mode aliases
- New jail fields: `exclude_files`, `watch_mode`, `query_before_match`, `action_timeout`
- `on_add` replaces `on_match` (deprecated alias noted)
- Updated fragment files note (supports `jails:` and `whitelists:` keys)
- Updated validation rules

## docs/jailtime.md
- `config global` command
- `perf` command with output field table
- `whitelist status|start|stop|restart` commands