### PR TITLE
fix: order whitelists and jails by source filename, not jail name

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -73,7 +73,30 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config file %q: %w", path, err)
 	}
 
-	// Expand include globs and merge jails/whitelists from fragment files.
+	c := &Config{
+		Version: raw.Version,
+		Include: raw.Include,
+		Logging: raw.Logging,
+		Control: raw.Control,
+		Engine: EngineConfig{
+			WatcherMode:   raw.Engine.WatcherMode,
+			PollInterval:  raw.Engine.PollInterval,
+			TargetLatency: raw.Engine.TargetLatency,
+		},
+		Actions: raw.Actions,
+	}
+
+	// Main config jails/whitelists come first; source file is the main config path.
+	for _, rj := range raw.Jails {
+		c.Jails = append(c.Jails, buildJailConfig(rj, path))
+	}
+	for _, rj := range raw.Whitelists {
+		c.Whitelists = append(c.Whitelists, buildJailConfig(rj, path))
+	}
+
+	// Expand include globs and append fragment jails/whitelists in filename order.
+	// filepath.Glob returns matches sorted lexicographically, so the 010-/020-/...
+	// naming convention naturally yields the intended startup order.
 	for _, pattern := range raw.Include {
 		if !filepath.IsAbs(pattern) {
 			pattern = filepath.Join(filepath.Dir(path), pattern)
@@ -91,29 +114,13 @@ func Load(path string) (*Config, error) {
 			if err != nil {
 				return nil, fmt.Errorf("include %q: %w", inc, err)
 			}
-			raw.Jails = append(raw.Jails, extraJails...)
-			raw.Whitelists = append(raw.Whitelists, extraWhitelists...)
+			for _, rj := range extraJails {
+				c.Jails = append(c.Jails, buildJailConfig(rj, inc))
+			}
+			for _, rj := range extraWhitelists {
+				c.Whitelists = append(c.Whitelists, buildJailConfig(rj, inc))
+			}
 		}
-	}
-
-	c := &Config{
-		Version: raw.Version,
-		Include: raw.Include,
-		Logging: raw.Logging,
-		Control: raw.Control,
-		Engine: EngineConfig{
-			WatcherMode:   raw.Engine.WatcherMode,
-			PollInterval:  raw.Engine.PollInterval,
-			TargetLatency: raw.Engine.TargetLatency,
-		},
-		Actions: raw.Actions,
-	}
-
-	for _, rj := range raw.Jails {
-		c.Jails = append(c.Jails, buildJailConfig(rj))
-	}
-	for _, rj := range raw.Whitelists {
-		c.Whitelists = append(c.Whitelists, buildJailConfig(rj))
 	}
 
 	applyDefaults(c, raw.Engine.ReadFromEnd, raw.Engine.PerfWindow)
@@ -126,7 +133,8 @@ func Load(path string) (*Config, error) {
 
 // buildJailConfig converts a rawJailConfig to a JailConfig, applying
 // OnMatch→OnAdd deprecation alias and pointer-bool defaults.
-func buildJailConfig(rj rawJailConfig) JailConfig {
+// sourceFile is the path of the config file that defined this jail.
+func buildJailConfig(rj rawJailConfig, sourceFile string) JailConfig {
 	actions := rj.Actions
 	// OnMatch is a deprecated alias for OnAdd; merge at load time.
 	if len(actions.OnAdd) == 0 && len(actions.OnMatch) > 0 {
@@ -135,6 +143,7 @@ func buildJailConfig(rj rawJailConfig) JailConfig {
 	}
 
 	jc := JailConfig{
+		SourceFile:     sourceFile,
 		Name:           rj.Name,
 		Files:          rj.Files,
 		ExcludeFiles:   rj.ExcludeFiles,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -52,6 +52,9 @@ type EngineConfig struct {
 
 // JailConfig defines a single jail rule.
 type JailConfig struct {
+	// SourceFile is the path of the config file from which this jail was loaded.
+	// It is set during loading and is not part of the YAML schema.
+	SourceFile     string      `yaml:"-"`
 	Name           string      `yaml:"name"`
 	Enabled        bool        `yaml:"enabled"`
 	Files          []string    `yaml:"files"`

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -77,7 +77,9 @@ func NewManager(cfg *config.Config, configPath string) (*Manager, error) {
 // then starts all enabled jails, then starts the watch backend.
 // Global on_start actions run before any whitelist or jail is started;
 // global on_stop actions run after all have stopped.
-// Within each group, start/stop order is alphabetical by name.
+// Within each group, start/stop order is by source filename (lexicographic),
+// matching the 010-/020-/... naming convention used for fragment files.
+// Jails with the same source file are ordered by name as a tiebreaker.
 func (m *Manager) Run(ctx context.Context) error {
 	// Run global on_start actions before starting any jail or whitelist.
 	if len(m.cfg.Actions.OnStart) > 0 {
@@ -87,7 +89,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		}
 	}
 
-	// Start whitelists first (alphabetical) so their static membership is ready before jails process events.
+	// Start whitelists first (by source filename) so their static membership is ready before jails process events.
 	for _, name := range sortedKeys(m.whitelists) {
 		jr := m.whitelists[name]
 		if !jr.cfg.Enabled {
@@ -97,7 +99,7 @@ func (m *Manager) Run(ctx context.Context) error {
 			return fmt.Errorf("starting whitelist %q: %w", name, err)
 		}
 	}
-	// Start jails in alphabetical order.
+	// Start jails in source filename order.
 	for _, name := range sortedKeys(m.jails) {
 		jr := m.jails[name]
 		if !jr.cfg.Enabled {
@@ -374,13 +376,22 @@ func buildSpecs(jails map[string]*JailRuntime, readFromEnd bool) []watch.WatchSp
 	return specs
 }
 
-// sortedKeys returns the keys of m in sorted order.
+// sortedKeys returns the keys of m sorted by source filename, with jail name
+// as a tiebreaker for jails sharing the same source file. This preserves the
+// 010-/020-/... fragment file naming convention as the startup/stop order.
 func sortedKeys(m map[string]*JailRuntime) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool {
+		si := m[keys[i]].cfg.SourceFile
+		sj := m[keys[j]].cfg.SourceFile
+		if si != sj {
+			return si < sj
+		}
+		return keys[i] < keys[j]
+	})
 	return keys
 }
 

--- a/internal/engine/manager_test.go
+++ b/internal/engine/manager_test.go
@@ -12,17 +12,31 @@ import (
 	"github.com/sgw/jailtime/internal/watch"
 )
 
-// TestSortedKeys verifies that sortedKeys returns map keys in alphabetical order.
+// TestSortedKeys verifies that sortedKeys orders by source filename first, then
+// by jail name as a tiebreaker for jails in the same file.
 func TestSortedKeys(t *testing.T) {
+	// All keys with no source file — falls back to name order.
 	m := map[string]*JailRuntime{
-		"zebra":  {},
-		"alpha":  {},
-		"middle": {},
+		"zebra":  {cfg: &config.JailConfig{Name: "zebra"}},
+		"alpha":  {cfg: &config.JailConfig{Name: "alpha"}},
+		"middle": {cfg: &config.JailConfig{Name: "middle"}},
 	}
 	got := sortedKeys(m)
 	want := []string{"alpha", "middle", "zebra"}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
-		t.Errorf("sortedKeys = %v, want %v", got, want)
+		t.Errorf("sortedKeys (no source file) = %v, want %v", got, want)
+	}
+
+	// Keys with distinct source files — ordered by filename, not by name.
+	m2 := map[string]*JailRuntime{
+		"stripe":      {cfg: &config.JailConfig{Name: "stripe", SourceFile: "/etc/jailtime/jails/010-stripe.yaml"}},
+		"apache":      {cfg: &config.JailConfig{Name: "apache", SourceFile: "/etc/jailtime/jails/020-apache.yaml"}},
+		"uptimerobot": {cfg: &config.JailConfig{Name: "uptimerobot", SourceFile: "/etc/jailtime/jails/005-uptimerobot.yaml"}},
+	}
+	got2 := sortedKeys(m2)
+	want2 := []string{"uptimerobot", "stripe", "apache"}
+	if fmt.Sprint(got2) != fmt.Sprint(want2) {
+		t.Errorf("sortedKeys (by source file) = %v, want %v", got2, want2)
 	}
 }
 
@@ -112,7 +126,81 @@ func TestGlobalOnStartRunsBeforeJails(t *testing.T) {
 	}
 }
 
-// TestJailsStartInAlphabeticalOrder verifies that jails are started in sorted order.
+// TestJailsStartInFilenameOrder verifies that jails without a source file fall
+// back to name order, and that jails with distinct source files start in
+// source-filename order regardless of jail name.
+func TestJailsStartInFilenameOrder(t *testing.T) {
+	dir := t.TempDir()
+	outFile := dir + "/order.txt"
+	logFile := dir + "/app.log"
+	if err := os.WriteFile(logFile, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			WatcherMode:   "poll",
+			PollInterval:  config.Duration{Duration: 50 * time.Millisecond},
+			ReadFromEnd:   true,
+			TargetLatency: config.Duration{Duration: 50 * time.Millisecond},
+			PerfWindow:    1,
+		},
+	}
+
+	// Jail names are reverse-alphabetical but source files are numbered so that
+	// the expected startup order is stripe → apache → uptimerobot.
+	type entry struct {
+		name string
+		file string
+	}
+	entries := []entry{
+		{"uptimerobot", "/etc/jailtime/jails/030-uptimerobot.yaml"},
+		{"stripe", "/etc/jailtime/jails/010-stripe.yaml"},
+		{"apache", "/etc/jailtime/jails/020-apache.yaml"},
+	}
+
+	jails := map[string]*JailRuntime{}
+	for _, e := range entries {
+		jailCfg := makeMinimalJailCfg(e.name, logFile, outFile)
+		jailCfg.SourceFile = e.file
+		jr, err := NewJailRuntime(jailCfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		jails[e.name] = jr
+	}
+
+	m := &Manager{
+		cfg:        cfg,
+		jails:      jails,
+		whitelists: map[string]*JailRuntime{},
+		backend:    watch.NewAuto("poll", 50*time.Millisecond),
+		perf:       NewPerfMetrics(50*time.Millisecond, 1, ""),
+	}
+	m.currentInterval = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Run(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{"stripe", "apache", "uptimerobot"}
+	if fmt.Sprint(lines) != fmt.Sprint(want) {
+		t.Errorf("jail startup order = %v, want %v", lines, want)
+	}
+}
+
+// TestJailsStartInAlphabeticalOrder verifies that jails without a source file
+// fall back to alphabetical name order.
 func TestJailsStartInAlphabeticalOrder(t *testing.T) {
 	dir := t.TempDir()
 	outFile := dir + "/order.txt"


### PR DESCRIPTION
Fixes #28.

## Problem

Jails and whitelists were started/stopped in alphabetical order by their `name` field. Users organise fragment files with a numeric prefix (`010-stripe.yaml`, `020-apache.yaml`, …) so that firewall rules appear in a deliberate order, but sorting by name ignored that convention entirely.

## Solution

- Add `SourceFile string` (not exposed to YAML) to `JailConfig` so each jail records the path of the config file it was loaded from.
- Refactor `config.Load` to set `SourceFile` on every `JailConfig`: main-config jails get the main config path; fragment jails get their fragment file path. Fragment files are appended in `filepath.Glob` order (lexicographic), which is exactly the `010-/020-/…` ordering users rely on.
- Change `sortedKeys()` in the engine `Manager` to sort by `(SourceFile, Name)`: startup/stop order now matches source-filename order. Jails with identical or empty source files fall back to name as a tiebreaker (preserving existing behaviour for inline/test configs).
- Updated `TestSortedKeys` to cover both cases.
- Added `TestJailsStartInFilenameOrder` which creates three jails whose names are reverse-alphabetical but whose source files are numbered `010/020/030` and verifies they start in filename order.