### PR TITLE
fix(perf): split latency into event-to-drain latency and inter-drain

### DIFF
--- a/cmd/jailtime/main.go
+++ b/cmd/jailtime/main.go
@@ -191,11 +191,12 @@ matched. No hit counts are modified and no actions are executed.`,
 			fmt.Printf("Config:\n")
 			fmt.Printf("  Target Latency: %.0fms\n", resp.TargetLatencyMs)
 			fmt.Printf("\nPerformance:\n")
-			fmt.Printf("  Latency:   %.0fms\n", resp.LatencyMs)
-			fmt.Printf("  Execution: %.0fms\n", resp.ExecutionMs)
-			fmt.Printf("  Sleep:     %.0fms\n", resp.SleepMs)
-			fmt.Printf("  Lines:     %d\n", resp.LinesProcessed)
-			fmt.Printf("  CPU Usage: %.1f%%\n", resp.CPUPercent)
+			fmt.Printf("  Latency:    %.0fms\n", resp.LatencyMs)
+			fmt.Printf("  Inter Drain:%.0fms\n", resp.InterDrainMs)
+			fmt.Printf("  Execution:  %.0fms\n", resp.ExecutionMs)
+			fmt.Printf("  Sleep:      %.0fms\n", resp.SleepMs)
+			fmt.Printf("  Lines:      %d\n", resp.LinesProcessed)
+			fmt.Printf("  CPU Usage:  %.1f%%\n", resp.CPUPercent)
 			return nil
 		},
 	}

--- a/cmd/jailtimed/main.go
+++ b/cmd/jailtimed/main.go
@@ -177,6 +177,7 @@ func (a *JailControllerAdapter) PerfStats() control.PerfResponse {
 	return control.PerfResponse{
 		TargetLatencyMs: snap.TargetLatencyMs,
 		LatencyMs:       snap.LatencyMs,
+		InterDrainMs:    snap.InterDrainMs,
 		ExecutionMs:     snap.ExecutionMs,
 		SleepMs:         snap.SleepMs,
 		LinesProcessed:  snap.LinesProcessed,

--- a/internal/control/api.go
+++ b/internal/control/api.go
@@ -38,6 +38,7 @@ type ConfigTestResponse struct {
 type PerfResponse struct {
 	TargetLatencyMs float64 `json:"target_latency_ms"`
 	LatencyMs       float64 `json:"latency_ms"`
+	InterDrainMs    float64 `json:"inter_drain_ms"`
 	ExecutionMs     float64 `json:"execution_ms"`
 	SleepMs         float64 `json:"sleep_ms"`
 	LinesProcessed  int     `json:"lines_processed"`

--- a/internal/engine/manager.go
+++ b/internal/engine/manager.go
@@ -151,6 +151,18 @@ func (m *Manager) processDrain(ctx context.Context, lines []watch.RawLine) {
 	}
 	m.lastDrainAt = drainStart
 
+	// Compute event-to-drain latency as the time from the earliest EnqueueAt
+	// in the batch to drain start. For fsnotify, EnqueueAt is set when the
+	// write event first triggers the drain timer; for poll, it's the tick time.
+	var eventLatency time.Duration
+	for _, l := range lines {
+		if !l.EnqueueAt.IsZero() {
+			if d := drainStart.Sub(l.EnqueueAt); eventLatency == 0 || d < eventLatency {
+				eventLatency = d
+			}
+		}
+	}
+
 	// Intended sleep steers towards targetLatency using the moving average of
 	// previous execution times: sleep = targetLatency - movingAvgExec.
 	// This ensures sleep is always <= targetLatency regardless of OS scheduling drift.
@@ -159,7 +171,7 @@ func (m *Manager) processDrain(ctx context.Context, lines []watch.RawLine) {
 	m.processBatch(ctx, lines)
 
 	execTime := time.Since(drainStart)
-	m.perf.RecordExecution(execTime, m.currentInterval, intendedSleep, len(lines))
+	m.perf.RecordExecution(execTime, eventLatency, m.currentInterval, intendedSleep, len(lines))
 }
 
 func (m *Manager) processBatch(ctx context.Context, lines []watch.RawLine) {

--- a/internal/engine/perf.go
+++ b/internal/engine/perf.go
@@ -9,6 +9,7 @@ import (
 type PerfSnapshot struct {
 	TargetLatencyMs float64 `json:"target_latency_ms"`
 	LatencyMs       float64 `json:"latency_ms"`
+	InterDrainMs    float64 `json:"inter_drain_ms"`
 	ExecutionMs     float64 `json:"execution_ms"`
 	SleepMs         float64 `json:"sleep_ms"`
 	LinesProcessed  int     `json:"lines_processed"`
@@ -21,10 +22,11 @@ type PerfMetrics struct {
 
 	targetLatency time.Duration
 
-	lastLatency time.Duration
-	lastExec    time.Duration
-	lastSleep   time.Duration
-	lastLines   int
+	lastLatency   time.Duration
+	lastInterDrain time.Duration
+	lastExec      time.Duration
+	lastSleep     time.Duration
+	lastLines     int
 
 	// execWindow is a ring buffer holding the last perfWindow execution times.
 	execWindow []time.Duration
@@ -47,14 +49,17 @@ func NewPerfMetrics(targetLatency time.Duration, perfWindow int, serviceName str
 }
 
 // RecordExecution is called after each batch drain.
+// latency is the time from the first event trigger to drain start.
+// interDrain is the elapsed time between this drain and the previous one.
 // sleepTime is the intended sleep before the next drain.
 // batchSize 0 means no lines were processed; CPU is not sampled in that case.
-func (p *PerfMetrics) RecordExecution(execTime, latency, sleepTime time.Duration, batchSize int) {
+func (p *PerfMetrics) RecordExecution(execTime, latency, interDrain, sleepTime time.Duration, batchSize int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	p.lastExec = execTime
 	p.lastLatency = latency
+	p.lastInterDrain = interDrain
 	p.lastSleep = sleepTime
 	p.lastLines = batchSize
 
@@ -137,6 +142,7 @@ func (p *PerfMetrics) Snapshot() PerfSnapshot {
 	return PerfSnapshot{
 		TargetLatencyMs: float64(p.targetLatency.Microseconds()) / 1000.0,
 		LatencyMs:       float64(p.lastLatency.Microseconds()) / 1000.0,
+		InterDrainMs:    float64(p.lastInterDrain.Microseconds()) / 1000.0,
 		ExecutionMs:     float64(p.lastExec.Microseconds()) / 1000.0,
 		SleepMs:         float64(p.lastSleep.Microseconds()) / 1000.0,
 		LinesProcessed:  p.lastLines,

--- a/internal/engine/perf_test.go
+++ b/internal/engine/perf_test.go
@@ -8,8 +8,8 @@ import (
 func TestPerfMetrics_SnapshotLastValues(t *testing.T) {
 	p := NewPerfMetrics(2*time.Second, 3, "nonexistent-service-for-test.service")
 
-	p.RecordExecution(10*time.Millisecond, 100*time.Millisecond, 90*time.Millisecond, 5)
-	p.RecordExecution(30*time.Millisecond, 120*time.Millisecond, 95*time.Millisecond, 8)
+	p.RecordExecution(10*time.Millisecond, 80*time.Millisecond, 100*time.Millisecond, 90*time.Millisecond, 5)
+	p.RecordExecution(30*time.Millisecond, 90*time.Millisecond, 120*time.Millisecond, 95*time.Millisecond, 8)
 
 	snap := p.Snapshot()
 
@@ -19,8 +19,11 @@ func TestPerfMetrics_SnapshotLastValues(t *testing.T) {
 	if snap.ExecutionMs != 30.0 {
 		t.Errorf("ExecutionMs = %v, want 30.0 (last value)", snap.ExecutionMs)
 	}
-	if snap.LatencyMs != 120.0 {
-		t.Errorf("LatencyMs = %v, want 120.0 (last value)", snap.LatencyMs)
+	if snap.LatencyMs != 90.0 {
+		t.Errorf("LatencyMs = %v, want 90.0 (last event latency)", snap.LatencyMs)
+	}
+	if snap.InterDrainMs != 120.0 {
+		t.Errorf("InterDrainMs = %v, want 120.0 (last inter-drain)", snap.InterDrainMs)
 	}
 	if snap.SleepMs != 95.0 {
 		t.Errorf("SleepMs = %v, want 95.0 (last value)", snap.SleepMs)
@@ -40,6 +43,9 @@ func TestPerfMetrics_ZeroBeforeFirstRecord(t *testing.T) {
 	if snap.LatencyMs != 0 {
 		t.Errorf("LatencyMs = %v before any record, want 0", snap.LatencyMs)
 	}
+	if snap.InterDrainMs != 0 {
+		t.Errorf("InterDrainMs = %v before any record, want 0", snap.InterDrainMs)
+	}
 	if snap.LinesProcessed != 0 {
 		t.Errorf("LinesProcessed = %v before any record, want 0", snap.LinesProcessed)
 	}
@@ -48,7 +54,7 @@ func TestPerfMetrics_ZeroBeforeFirstRecord(t *testing.T) {
 func TestPerfMetrics_UnavailableCgroupNoPanic(t *testing.T) {
 	// Must not panic even when cgroup path doesn't exist.
 	p := NewPerfMetrics(2*time.Second, 3, "no-such-service-xyz-123.service")
-	p.RecordExecution(1*time.Millisecond, 10*time.Millisecond, 9*time.Millisecond, 1)
+	p.RecordExecution(1*time.Millisecond, 5*time.Millisecond, 10*time.Millisecond, 9*time.Millisecond, 1)
 	snap := p.Snapshot()
 	if snap.TargetLatencyMs != 2000.0 {
 		t.Errorf("TargetLatencyMs = %v, want 2000.0", snap.TargetLatencyMs)
@@ -71,7 +77,7 @@ func TestPerfMetrics_IntendedSleepNeverExceedsTarget(t *testing.T) {
 	}
 
 	// After recording a fast execution, sleep should be slightly below target.
-	p.RecordExecution(10*time.Millisecond, target, target-10*time.Millisecond, 5)
+	p.RecordExecution(10*time.Millisecond, 10*time.Millisecond, target, target-10*time.Millisecond, 5)
 	sleep = p.IntendedSleep()
 	if sleep > target {
 		t.Errorf("IntendedSleep = %v exceeds targetLatency %v", sleep, target)
@@ -79,7 +85,7 @@ func TestPerfMetrics_IntendedSleepNeverExceedsTarget(t *testing.T) {
 
 	// After recording a slow execution (larger than target), sleep should be 0.
 	p2 := NewPerfMetrics(50*time.Millisecond, 1, "nonexistent-service-for-test.service")
-	p2.RecordExecution(100*time.Millisecond, 100*time.Millisecond, 0, 1)
+	p2.RecordExecution(100*time.Millisecond, 50*time.Millisecond, 100*time.Millisecond, 0, 1)
 	sleep2 := p2.IntendedSleep()
 	if sleep2 != 0 {
 		t.Errorf("IntendedSleep = %v, want 0 when exec > target", sleep2)
@@ -93,7 +99,7 @@ func TestPerfMetrics_MovingAvgWindow(t *testing.T) {
 	// ring buffer holds [40, 20, 30] (oldest entry overwritten), avg = 30ms.
 	p := NewPerfMetrics(2*time.Second, 3, "nonexistent-service-for-test.service")
 	for _, d := range []time.Duration{10, 20, 30, 40} {
-		p.RecordExecution(d*time.Millisecond, 2*time.Second, 0, 1)
+		p.RecordExecution(d*time.Millisecond, 0, 2*time.Second, 0, 1)
 	}
 
 	avg := p.MovingAvgExec()

--- a/internal/watch/fsnotify.go
+++ b/internal/watch/fsnotify.go
@@ -74,6 +74,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 
 	var drainTimerC <-chan time.Time // nil = idle
 	var lastDrainTime time.Duration  // previous drain wall time
+	var pendingTriggerAt time.Time   // when the current pending drain was first triggered
 
 	readTailLines := func(p string) []RawLine {
 		ft, ok := tailers[p]
@@ -146,6 +147,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 		if drainTimerC != nil {
 			return
 		}
+		pendingTriggerAt = time.Now()
 		wait := b.getDrainInterval() - lastDrainTime
 		if wait < time.Millisecond {
 			wait = time.Millisecond
@@ -316,6 +318,8 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 		case <-drainTimerC:
 			drainStart := time.Now()
 			drainTimerC = nil
+			triggerAt := pendingTriggerAt
+			pendingTriggerAt = time.Time{}
 			var batch []RawLine
 			for p := range dirty {
 				batch = append(batch, readTailLines(p)...)
@@ -324,6 +328,13 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 			for p := range staticDirty {
 				batch = append(batch, diffStaticLines(p)...)
 				delete(staticDirty, p)
+			}
+			// Backfill EnqueueAt to the event trigger time so callers can
+			// compute true event-to-drain latency.
+			if !triggerAt.IsZero() {
+				for i := range batch {
+					batch[i].EnqueueAt = triggerAt
+				}
 			}
 			drain(ctx, batch)
 			lastDrainTime = time.Since(drainStart)


### PR DESCRIPTION
Fixes #30

## Summary

The `latency_ms` metric was misleadingly named — it was actually measuring the **inter-drain interval** (time between successive drains), not the time from event trigger to drain.

## Changes

- **`latency_ms`** is now the true **event-to-drain latency**: computed as `drainStart - min(EnqueueAt)` across the batch.
  - For fsnotify: `EnqueueAt` is now set when the write event first arms the drain timer, so `latency_ms ≈ targetLatency` as expected.
  - For poll: `EnqueueAt` is the tick time (lines are read and drained in the same tick), so `latency_ms ≈ 0`.
- **`inter_drain_ms`** is the new metric capturing the old semantics: elapsed time between successive drain calls.
- `RecordExecution` gains a separate `interDrain` parameter.
- CLI `jailtime perf` now displays both **Latency** and **Inter Drain**.
- All tests updated.