### PR TITLE
feat: tags_from — configurable multi-source tagging for actions and logging (closes #35)

### DIFF
--- a/docs/jailtimed.md
+++ b/docs/jailtimed.md
@@ -301,7 +301,8 @@ jails:
   - name: apache-vhosts
     files:
       - /var/log/apache2/*/access.log
-    tags_from: [parent_dir]
+    tags_from:
+      - parent_dir
     filters:
       - '(?P<ip>[0-9.]+) .* " [45][0-9][0-9] '
     actions:
@@ -314,7 +315,9 @@ If the matched file is `/var/log/apache2/site.example/access.log` then `{{ .Tags
 **Example — combine parent directory and a filter capture group:**
 
 ```yaml
-tags_from: [parent_dir, match_tag1]
+tags_from:
+  - parent_dir
+  - match_tag1
 filters:
   - '(?P<ip>[0-9.]+).*service=(?P<tag1>\w+)'
 # Tags = "site.example,webapp"

--- a/docs/jailtimed.md
+++ b/docs/jailtimed.md
@@ -218,6 +218,7 @@ jails:
 | `watch_mode` | string | `tail` | `tail` — watch log files for new lines; `static` — watch a file of IP/CIDR entries (see Whitelists) |
 | `query` | string | — | Pre-check command; see `query_before_match` |
 | `query_before_match` | bool | `false` | When `true`, run `query` before `on_add`; if `query` exits **0**, `on_add` is skipped |
+| `tags_from` | []string | `[]` | Ordered list of tag sources; resolved values are joined with `,` and exposed as `{{ .Tags }}` — see [Tags](#tags) |
 | `action_timeout` | duration | `30s` | Maximum time allowed for each individual action command |
 | `actions` | object | — | Shell commands for lifecycle events (see below) |
 
@@ -282,6 +283,45 @@ exclude_filters:
   - 'from 192\.168\.'        # ignore RFC-1918 sources
 ```
 
+### Tags
+
+The `tags_from` field is an ordered array of tag source names. Each source is resolved to a string; empty values are omitted. The remaining values are joined with `,` to form the `{{ .Tags }}` template variable and the `tags` structured log field.
+
+| Source | Produces |
+|---|---|
+| `parent_dir` | Base name of the directory containing the matched log file |
+| `match_tag1`…`match_tag9` | Text captured by `(?P<tag1>…)`…`(?P<tag9>…)` named groups in the matched filter |
+
+`tags_from` defaults to `[]` (empty — no tags computed or logged).
+
+**Example — log the virtual-host name:**
+
+```yaml
+jails:
+  - name: apache-vhosts
+    files:
+      - /var/log/apache2/*/access.log
+    tags_from: [parent_dir]
+    filters:
+      - '(?P<ip>[0-9.]+) .* " [45][0-9][0-9] '
+    actions:
+      on_add:
+        - 'nft add element inet filter blacklist { {{ .IP }} } comment "{{ .Tags }}"'
+```
+
+If the matched file is `/var/log/apache2/site.example/access.log` then `{{ .Tags }}` evaluates to `site.example`.
+
+**Example — combine parent directory and a filter capture group:**
+
+```yaml
+tags_from: [parent_dir, match_tag1]
+filters:
+  - '(?P<ip>[0-9.]+).*service=(?P<tag1>\w+)'
+# Tags = "site.example,webapp"
+```
+
+---
+
 ### `query` — pre-check
 
 When `query_before_match: true` and `query` is set, jailtimed runs the query as
@@ -327,6 +367,7 @@ actions fails validation. (`on_match` is accepted as a deprecated alias for `on_
 | `{{ .FindTime }}` | `find_time` expressed in seconds (integer) |
 | `{{ .HitCount }}` | Hit count at the moment the threshold was crossed |
 | `{{ .Timestamp }}` | RFC3339 timestamp of the match event |
+| `{{ .Tags }}` | Comma-joined tag values from `tags_from` (empty string when no tags configured) |
 
 ---
 
@@ -370,6 +411,7 @@ reported with the jail name and field:
 - `hit_count` must be ≥ 1
 - `net_type` must be `IP` or `CIDR`
 - All `filters` and `exclude_filters` must be valid Go regular expressions
+- Each entry in `tags_from` must be `"parent_dir"` or `"match_tag1"`…`"match_tag9"`
 
 ---
 

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -28,6 +28,26 @@ func TestRenderJailTime(t *testing.T) {
 	}
 }
 
+func TestRenderLabel(t *testing.T) {
+	result, err := Render("label={{ .Label }}", Context{Label: "some-domain.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "label=some-domain.com" {
+		t.Errorf("got %q, want %q", result, "label=some-domain.com")
+	}
+}
+
+func TestRenderLabelEmpty(t *testing.T) {
+	result, err := Render("{{ .IP }} label={{ .Label }}", Context{IP: "1.2.3.4"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "1.2.3.4 label=" {
+		t.Errorf("got %q, want %q", result, "1.2.3.4 label=")
+	}
+}
+
 func TestRenderInvalidTemplate(t *testing.T) {
 	_, err := Render("{{ .IP", Context{})
 	if err == nil {

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -28,23 +28,23 @@ func TestRenderJailTime(t *testing.T) {
 	}
 }
 
-func TestRenderLabel(t *testing.T) {
-	result, err := Render("label={{ .Label }}", Context{Label: "some-domain.com"})
+func TestRenderTags(t *testing.T) {
+	result, err := Render("tags={{ .Tags }}", Context{Tags: "some-domain.com,webapp"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result != "label=some-domain.com" {
-		t.Errorf("got %q, want %q", result, "label=some-domain.com")
+	if result != "tags=some-domain.com,webapp" {
+		t.Errorf("got %q, want %q", result, "tags=some-domain.com,webapp")
 	}
 }
 
-func TestRenderLabelEmpty(t *testing.T) {
-	result, err := Render("{{ .IP }} label={{ .Label }}", Context{IP: "1.2.3.4"})
+func TestRenderTagsEmpty(t *testing.T) {
+	result, err := Render("{{ .IP }} tags={{ .Tags }}", Context{IP: "1.2.3.4"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result != "1.2.3.4 label=" {
-		t.Errorf("got %q, want %q", result, "1.2.3.4 label=")
+	if result != "1.2.3.4 tags=" {
+		t.Errorf("got %q, want %q", result, "1.2.3.4 tags=")
 	}
 }
 

--- a/internal/action/template.go
+++ b/internal/action/template.go
@@ -7,16 +7,13 @@ import (
 
 // Context holds values available in action command templates.
 type Context struct {
-	IP        string
-	Jail      string
-	File      string
-	Line      string
-	// Label is a user-configured value that identifies the source of the match.
-	// Its content is determined by the jail's label_from setting:
-	//   "match"      (default) – text captured by (?P<label>...) in the filter
-	//   "parent_dir"           – name of the directory containing File
-	// Empty when the configured source yields no value.
-	Label     string
+	IP       string
+	Jail     string
+	File     string
+	Line     string
+	// Tags is the comma-joined list of tag values resolved from the jail's
+	// tags_from config. Empty string when tags_from is empty or yields no values.
+	Tags      string
 	JailTime  int64 // seconds
 	FindTime  int64 // seconds
 	HitCount  int

--- a/internal/action/template.go
+++ b/internal/action/template.go
@@ -11,6 +11,12 @@ type Context struct {
 	Jail      string
 	File      string
 	Line      string
+	// Label is a user-configured value that identifies the source of the match.
+	// Its content is determined by the jail's label_from setting:
+	//   "match"      (default) – text captured by (?P<label>...) in the filter
+	//   "parent_dir"           – name of the directory containing File
+	// Empty when the configured source yields no value.
+	Label     string
 	JailTime  int64 // seconds
 	FindTime  int64 // seconds
 	HitCount  int

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -176,6 +176,50 @@ func TestLoadActionTimeoutExplicit(t *testing.T) {
 	}
 }
 
+func TestLoadLabelFromDefault(t *testing.T) {
+	path := writeTemp(t, minimalValidYAML)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if c.Jails[0].LabelFrom != "" {
+		t.Errorf("LabelFrom should default to empty string, got %q", c.Jails[0].LabelFrom)
+	}
+}
+
+func TestLoadLabelFromParentDir(t *testing.T) {
+	y := minimalValidYAML + "    label_from: parent_dir\n"
+	path := writeTemp(t, y)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if c.Jails[0].LabelFrom != "parent_dir" {
+		t.Errorf("LabelFrom = %q, want %q", c.Jails[0].LabelFrom, "parent_dir")
+	}
+}
+
+func TestLoadLabelFromMatch(t *testing.T) {
+	y := minimalValidYAML + "    label_from: match\n"
+	path := writeTemp(t, y)
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if c.Jails[0].LabelFrom != "match" {
+		t.Errorf("LabelFrom = %q, want %q", c.Jails[0].LabelFrom, "match")
+	}
+}
+
+func TestLoadLabelFromInvalid(t *testing.T) {
+	y := minimalValidYAML + "    label_from: bogus\n"
+	path := writeTemp(t, y)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid label_from, got nil")
+	}
+}
+
 const jailFragmentYAML = `
 jails:
   - name: nginx

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -176,47 +176,58 @@ func TestLoadActionTimeoutExplicit(t *testing.T) {
 	}
 }
 
-func TestLoadLabelFromDefault(t *testing.T) {
+func TestLoadTagsFromDefault(t *testing.T) {
 	path := writeTemp(t, minimalValidYAML)
 	c, err := Load(path)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
-	if c.Jails[0].LabelFrom != "" {
-		t.Errorf("LabelFrom should default to empty string, got %q", c.Jails[0].LabelFrom)
+	if len(c.Jails[0].TagsFrom) != 0 {
+		t.Errorf("TagsFrom should default to empty, got %v", c.Jails[0].TagsFrom)
 	}
 }
 
-func TestLoadLabelFromParentDir(t *testing.T) {
-	y := minimalValidYAML + "    label_from: parent_dir\n"
+func TestLoadTagsFromParentDir(t *testing.T) {
+	y := minimalValidYAML + "    tags_from: [parent_dir]\n"
 	path := writeTemp(t, y)
 	c, err := Load(path)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
-	if c.Jails[0].LabelFrom != "parent_dir" {
-		t.Errorf("LabelFrom = %q, want %q", c.Jails[0].LabelFrom, "parent_dir")
+	if len(c.Jails[0].TagsFrom) != 1 || c.Jails[0].TagsFrom[0] != "parent_dir" {
+		t.Errorf("TagsFrom = %v, want [parent_dir]", c.Jails[0].TagsFrom)
 	}
 }
 
-func TestLoadLabelFromMatch(t *testing.T) {
-	y := minimalValidYAML + "    label_from: match\n"
+func TestLoadTagsFromMultiple(t *testing.T) {
+	y := minimalValidYAML + "    tags_from: [parent_dir, match_tag1]\n"
 	path := writeTemp(t, y)
 	c, err := Load(path)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
-	if c.Jails[0].LabelFrom != "match" {
-		t.Errorf("LabelFrom = %q, want %q", c.Jails[0].LabelFrom, "match")
+	want := []string{"parent_dir", "match_tag1"}
+	if len(c.Jails[0].TagsFrom) != 2 || c.Jails[0].TagsFrom[0] != want[0] || c.Jails[0].TagsFrom[1] != want[1] {
+		t.Errorf("TagsFrom = %v, want %v", c.Jails[0].TagsFrom, want)
 	}
 }
 
-func TestLoadLabelFromInvalid(t *testing.T) {
-	y := minimalValidYAML + "    label_from: bogus\n"
+func TestLoadTagsFromInvalid(t *testing.T) {
+	y := minimalValidYAML + "    tags_from: [bogus]\n"
 	path := writeTemp(t, y)
 	_, err := Load(path)
 	if err == nil {
-		t.Fatal("expected error for invalid label_from, got nil")
+		t.Fatal("expected error for invalid tags_from entry, got nil")
+	}
+}
+
+func TestLoadTagsFromMatchTag0Invalid(t *testing.T) {
+	// match_tag0 is not valid; only match_tag1..match_tag9.
+	y := minimalValidYAML + "    tags_from: [match_tag0]\n"
+	path := writeTemp(t, y)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for match_tag0, got nil")
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -37,6 +37,7 @@ type rawJailConfig struct {
 	QueryBeforeMatch *bool       `yaml:"query_before_match"`
 	ActionTimeout    Duration    `yaml:"action_timeout"`
 	IgnoreSets       []string    `yaml:"ignore_sets"`
+	LabelFrom        string      `yaml:"label_from"`
 }
 
 // rawConfig mirrors Config but uses raw sub-types to allow default detection.
@@ -158,6 +159,7 @@ func buildJailConfig(rj rawJailConfig, sourceFile string) JailConfig {
 		Query:          rj.Query,
 		ActionTimeout:  rj.ActionTimeout,
 		IgnoreSets:     rj.IgnoreSets,
+		LabelFrom:      rj.LabelFrom,
 	}
 	if rj.Enabled == nil {
 		jc.Enabled = true

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -37,7 +37,7 @@ type rawJailConfig struct {
 	QueryBeforeMatch *bool       `yaml:"query_before_match"`
 	ActionTimeout    Duration    `yaml:"action_timeout"`
 	IgnoreSets       []string    `yaml:"ignore_sets"`
-	LabelFrom        string      `yaml:"label_from"`
+	TagsFrom         []string    `yaml:"tags_from"`
 }
 
 // rawConfig mirrors Config but uses raw sub-types to allow default detection.
@@ -159,7 +159,7 @@ func buildJailConfig(rj rawJailConfig, sourceFile string) JailConfig {
 		Query:          rj.Query,
 		ActionTimeout:  rj.ActionTimeout,
 		IgnoreSets:     rj.IgnoreSets,
-		LabelFrom:      rj.LabelFrom,
+		TagsFrom:       rj.TagsFrom,
 	}
 	if rj.Enabled == nil {
 		jc.Enabled = true

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -75,6 +75,12 @@ type JailConfig struct {
 	// on_add is always executed on a threshold hit.  When true, the query is
 	// run first; an exit code of 0 suppresses on_add (IP already handled).
 	QueryBeforeMatch bool `yaml:"query_before_match"`
+	// LabelFrom controls what value is exposed as {{.Label}} in action
+	// templates and written to the "label" log field on every match.
+	// Valid values:
+	//   "match"      (default) – text from the (?P<label>...) capture group
+	//   "parent_dir"           – name of the directory that contains the file
+	LabelFrom string `yaml:"label_from"`
 	// ActionTimeout is the maximum time allowed for each individual action
 	// command (on_add, query).  Defaults to defaultActionTimeout.
 	ActionTimeout Duration `yaml:"action_timeout"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -75,12 +75,14 @@ type JailConfig struct {
 	// on_add is always executed on a threshold hit.  When true, the query is
 	// run first; an exit code of 0 suppresses on_add (IP already handled).
 	QueryBeforeMatch bool `yaml:"query_before_match"`
-	// LabelFrom controls what value is exposed as {{.Label}} in action
-	// templates and written to the "label" log field on every match.
-	// Valid values:
-	//   "match"      (default) – text from the (?P<label>...) capture group
-	//   "parent_dir"           – name of the directory that contains the file
-	LabelFrom string `yaml:"label_from"`
+	// TagsFrom is an ordered list of tag sources whose resolved values are
+	// joined with "," and exposed as {{.Tags}} in action templates and as the
+	// "tags" structured log field on every match.
+	// Valid sources:
+	//   "parent_dir"              – base name of the directory containing the file
+	//   "match_tag1"…"match_tag9" – text from (?P<tag1>…)…(?P<tag9>…) in the filter
+	// Defaults to empty (no tags).
+	TagsFrom []string `yaml:"tags_from"`
 	// ActionTimeout is the maximum time allowed for each individual action
 	// command (on_add, query).  Defaults to defaultActionTimeout.
 	ActionTimeout Duration `yaml:"action_timeout"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -87,8 +87,10 @@ func validateJails(jails []JailConfig, names map[string]struct{}, isWhitelist bo
 			return fmt.Errorf("%s %q: net_type must be \"IP\" or \"CIDR\", got %q", kind, j.Name, j.NetType)
 		}
 
-		if j.LabelFrom != "" && j.LabelFrom != "match" && j.LabelFrom != "parent_dir" {
-			return fmt.Errorf("%s %q: label_from must be \"match\" or \"parent_dir\", got %q", kind, j.Name, j.LabelFrom)
+		for k, src := range j.TagsFrom {
+			if src != "parent_dir" && !isMatchTagSource(src) {
+				return fmt.Errorf("%s %q: tags_from[%d] %q: must be \"parent_dir\" or \"match_tag1\"…\"match_tag9\"", kind, j.Name, k, src)
+			}
 		}
 
 		for k, f := range j.Filters {
@@ -103,4 +105,17 @@ func validateJails(jails []JailConfig, names map[string]struct{}, isWhitelist bo
 		}
 	}
 	return nil
+}
+
+// isMatchTagSource reports whether s is a valid match_tagN source name
+// (match_tag1 through match_tag9).
+func isMatchTagSource(s string) bool {
+	if len(s) != len("match_tag1") {
+		return false
+	}
+	if s[:9] != "match_tag" {
+		return false
+	}
+	c := s[9]
+	return c >= '1' && c <= '9'
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -87,6 +87,10 @@ func validateJails(jails []JailConfig, names map[string]struct{}, isWhitelist bo
 			return fmt.Errorf("%s %q: net_type must be \"IP\" or \"CIDR\", got %q", kind, j.Name, j.NetType)
 		}
 
+		if j.LabelFrom != "" && j.LabelFrom != "match" && j.LabelFrom != "parent_dir" {
+			return fmt.Errorf("%s %q: label_from must be \"match\" or \"parent_dir\", got %q", kind, j.Name, j.LabelFrom)
+		}
+
 		for k, f := range j.Filters {
 			if _, err := regexp.Compile(f); err != nil {
 				return fmt.Errorf("%s %q: filter[%d] %q: invalid regex: %w", kind, j.Name, k, f, err)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1120,3 +1120,109 @@ func TestHandleEventCIDRWithSlashNormalized(t *testing.T) {
 		t.Errorf("expected IP in output to be 192.168.1.0/24, got %q", got)
 	}
 }
+
+// TestResolveLabelMatch verifies that resolveLabel returns the filter-captured
+// label when label_from is "match" or empty.
+func TestResolveLabelMatch(t *testing.T) {
+	for _, labelFrom := range []string{"", "match"} {
+		got := resolveLabel(labelFrom, "captured", "/var/log/svc/access.log")
+		if got != "captured" {
+			t.Errorf("resolveLabel(%q) = %q, want %q", labelFrom, got, "captured")
+		}
+	}
+}
+
+// TestResolveLabelParentDir verifies that resolveLabel returns the parent
+// directory name of the file when label_from is "parent_dir".
+func TestResolveLabelParentDir(t *testing.T) {
+	got := resolveLabel("parent_dir", "captured", "/var/log/apache2/some-domain.com/access.log")
+	if got != "some-domain.com" {
+		t.Errorf("resolveLabel(parent_dir) = %q, want %q", got, "some-domain.com")
+	}
+}
+
+// TestHandleEventLabelFromMatch verifies that with label_from unset the Label
+// template variable is populated from the (?P<label>...) capture group.
+func TestHandleEventLabelFromMatch(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "output.txt")
+
+	cfg := &config.JailConfig{
+		Name:     "label-match-jail",
+		Enabled:  true,
+		Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+) (?P<label>\S+)`},
+		HitCount: 1,
+		FindTime: config.Duration{Duration: time.Minute},
+		Actions: config.JailActions{
+			OnAdd: []string{"echo {{ .Label }} > " + outFile},
+		},
+		ActionTimeout: config.Duration{Duration: 5 * time.Second},
+	}
+
+	jr, err := NewJailRuntime(cfg)
+	if err != nil {
+		t.Fatalf("NewJailRuntime: %v", err)
+	}
+
+	if err := jr.HandleEvent(context.Background(), watch.Event{
+		JailName: cfg.Name,
+		FilePath: "/var/log/app.log",
+		Line:     "Failed from 1.2.3.4 webapp",
+		Time:     time.Now(),
+	}); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	jr.WaitForInflight()
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "webapp" {
+		t.Errorf("Label = %q, want %q", got, "webapp")
+	}
+}
+
+// TestHandleEventLabelFromParentDir verifies that with label_from: parent_dir
+// the Label template variable is populated with the parent directory name.
+func TestHandleEventLabelFromParentDir(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "output.txt")
+
+	cfg := &config.JailConfig{
+		Name:      "label-parentdir-jail",
+		Enabled:   true,
+		LabelFrom: "parent_dir",
+		Filters:   []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
+		HitCount:  1,
+		FindTime:  config.Duration{Duration: time.Minute},
+		Actions: config.JailActions{
+			OnAdd: []string{"echo {{ .Label }} > " + outFile},
+		},
+		ActionTimeout: config.Duration{Duration: 5 * time.Second},
+	}
+
+	jr, err := NewJailRuntime(cfg)
+	if err != nil {
+		t.Fatalf("NewJailRuntime: %v", err)
+	}
+
+	if err := jr.HandleEvent(context.Background(), watch.Event{
+		JailName: cfg.Name,
+		FilePath: "/var/log/apache2/some-domain.com/access.log",
+		Line:     "Failed from 1.2.3.4",
+		Time:     time.Now(),
+	}); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	jr.WaitForInflight()
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "some-domain.com" {
+		t.Errorf("Label = %q, want %q", got, "some-domain.com")
+	}
+}
+

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1121,83 +1121,66 @@ func TestHandleEventCIDRWithSlashNormalized(t *testing.T) {
 	}
 }
 
-// TestResolveLabelMatch verifies that resolveLabel returns the filter-captured
-// label when label_from is "match" or empty.
-func TestResolveLabelMatch(t *testing.T) {
-	for _, labelFrom := range []string{"", "match"} {
-		got := resolveLabel(labelFrom, "captured", "/var/log/svc/access.log")
-		if got != "captured" {
-			t.Errorf("resolveLabel(%q) = %q, want %q", labelFrom, got, "captured")
-		}
+// TestResolveTagsParentDir verifies that resolveTags returns the parent
+// directory name of the file for the "parent_dir" source.
+func TestResolveTagsParentDir(t *testing.T) {
+	got := resolveTags([]string{"parent_dir"}, nil, "/var/log/apache2/some-domain.com/access.log")
+	if len(got) != 1 || got[0] != "some-domain.com" {
+		t.Errorf("resolveTags(parent_dir) = %v, want [some-domain.com]", got)
 	}
 }
 
-// TestResolveLabelParentDir verifies that resolveLabel returns the parent
-// directory name of the file when label_from is "parent_dir".
-func TestResolveLabelParentDir(t *testing.T) {
-	got := resolveLabel("parent_dir", "captured", "/var/log/apache2/some-domain.com/access.log")
-	if got != "some-domain.com" {
-		t.Errorf("resolveLabel(parent_dir) = %q, want %q", got, "some-domain.com")
+// TestResolveTagsMatchTag verifies that resolveTags extracts the correct named
+// capture group for a match_tagN source.
+func TestResolveTagsMatchTag(t *testing.T) {
+	groups := map[string]string{"tag1": "webapp", "tag2": "prod"}
+	got := resolveTags([]string{"match_tag1", "match_tag2"}, groups, "/var/log/app.log")
+	if len(got) != 2 || got[0] != "webapp" || got[1] != "prod" {
+		t.Errorf("resolveTags(match_tag1, match_tag2) = %v, want [webapp prod]", got)
 	}
 }
 
-// TestHandleEventLabelFromMatch verifies that with label_from unset the Label
-// template variable is populated from the (?P<label>...) capture group.
-func TestHandleEventLabelFromMatch(t *testing.T) {
+// TestResolveTagsMixed verifies multiple sources are combined in order.
+func TestResolveTagsMixed(t *testing.T) {
+	groups := map[string]string{"tag1": "webapp"}
+	got := resolveTags([]string{"parent_dir", "match_tag1"}, groups, "/var/log/apache2/site.example/access.log")
+	if len(got) != 2 || got[0] != "site.example" || got[1] != "webapp" {
+		t.Errorf("resolveTags(mixed) = %v, want [site.example webapp]", got)
+	}
+}
+
+// TestResolveTagsEmpty verifies an empty tags_from yields no tags.
+func TestResolveTagsEmpty(t *testing.T) {
+	got := resolveTags(nil, map[string]string{"tag1": "x"}, "/var/log/app.log")
+	if len(got) != 0 {
+		t.Errorf("resolveTags(nil) = %v, want []", got)
+	}
+}
+
+// TestResolveTagsMissingGroup verifies that a match_tagN source with no
+// corresponding capture group is silently omitted.
+func TestResolveTagsMissingGroup(t *testing.T) {
+	got := resolveTags([]string{"match_tag3"}, map[string]string{"tag1": "x"}, "/var/log/app.log")
+	if len(got) != 0 {
+		t.Errorf("resolveTags(missing group) = %v, want []", got)
+	}
+}
+
+// TestHandleEventTagsFromParentDir verifies that with tags_from: [parent_dir]
+// the Tags template variable contains the parent directory name.
+func TestHandleEventTagsFromParentDir(t *testing.T) {
 	dir := t.TempDir()
 	outFile := filepath.Join(dir, "output.txt")
 
 	cfg := &config.JailConfig{
-		Name:     "label-match-jail",
+		Name:     "tags-parentdir-jail",
 		Enabled:  true,
-		Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+) (?P<label>\S+)`},
+		TagsFrom: []string{"parent_dir"},
+		Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
 		HitCount: 1,
 		FindTime: config.Duration{Duration: time.Minute},
 		Actions: config.JailActions{
-			OnAdd: []string{"echo {{ .Label }} > " + outFile},
-		},
-		ActionTimeout: config.Duration{Duration: 5 * time.Second},
-	}
-
-	jr, err := NewJailRuntime(cfg)
-	if err != nil {
-		t.Fatalf("NewJailRuntime: %v", err)
-	}
-
-	if err := jr.HandleEvent(context.Background(), watch.Event{
-		JailName: cfg.Name,
-		FilePath: "/var/log/app.log",
-		Line:     "Failed from 1.2.3.4 webapp",
-		Time:     time.Now(),
-	}); err != nil {
-		t.Fatalf("HandleEvent: %v", err)
-	}
-	jr.WaitForInflight()
-
-	data, err := os.ReadFile(outFile)
-	if err != nil {
-		t.Fatalf("output file not created: %v", err)
-	}
-	if got := strings.TrimSpace(string(data)); got != "webapp" {
-		t.Errorf("Label = %q, want %q", got, "webapp")
-	}
-}
-
-// TestHandleEventLabelFromParentDir verifies that with label_from: parent_dir
-// the Label template variable is populated with the parent directory name.
-func TestHandleEventLabelFromParentDir(t *testing.T) {
-	dir := t.TempDir()
-	outFile := filepath.Join(dir, "output.txt")
-
-	cfg := &config.JailConfig{
-		Name:      "label-parentdir-jail",
-		Enabled:   true,
-		LabelFrom: "parent_dir",
-		Filters:   []string{`(?P<ip>\d+\.\d+\.\d+\.\d+)`},
-		HitCount:  1,
-		FindTime:  config.Duration{Duration: time.Minute},
-		Actions: config.JailActions{
-			OnAdd: []string{"echo {{ .Label }} > " + outFile},
+			OnAdd: []string{"echo {{ .Tags }} > " + outFile},
 		},
 		ActionTimeout: config.Duration{Duration: 5 * time.Second},
 	}
@@ -1222,7 +1205,93 @@ func TestHandleEventLabelFromParentDir(t *testing.T) {
 		t.Fatalf("output file not created: %v", err)
 	}
 	if got := strings.TrimSpace(string(data)); got != "some-domain.com" {
-		t.Errorf("Label = %q, want %q", got, "some-domain.com")
+		t.Errorf("Tags = %q, want %q", got, "some-domain.com")
+	}
+}
+
+// TestHandleEventTagsFromMatchTag verifies that tags_from: [match_tag1]
+// exposes the (?P<tag1>...) capture group as Tags.
+func TestHandleEventTagsFromMatchTag(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "output.txt")
+
+	cfg := &config.JailConfig{
+		Name:     "tags-matchtag-jail",
+		Enabled:  true,
+		TagsFrom: []string{"match_tag1"},
+		Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+) (?P<tag1>\S+)`},
+		HitCount: 1,
+		FindTime: config.Duration{Duration: time.Minute},
+		Actions: config.JailActions{
+			OnAdd: []string{"echo {{ .Tags }} > " + outFile},
+		},
+		ActionTimeout: config.Duration{Duration: 5 * time.Second},
+	}
+
+	jr, err := NewJailRuntime(cfg)
+	if err != nil {
+		t.Fatalf("NewJailRuntime: %v", err)
+	}
+
+	if err := jr.HandleEvent(context.Background(), watch.Event{
+		JailName: cfg.Name,
+		FilePath: "/var/log/app.log",
+		Line:     "Failed from 1.2.3.4 webapp",
+		Time:     time.Now(),
+	}); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	jr.WaitForInflight()
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "webapp" {
+		t.Errorf("Tags = %q, want %q", got, "webapp")
+	}
+}
+
+// TestHandleEventTagsFromMultiple verifies that multiple tags_from sources are
+// joined with "," in Tags.
+func TestHandleEventTagsFromMultiple(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "output.txt")
+
+	cfg := &config.JailConfig{
+		Name:     "tags-multi-jail",
+		Enabled:  true,
+		TagsFrom: []string{"parent_dir", "match_tag1"},
+		Filters:  []string{`(?P<ip>\d+\.\d+\.\d+\.\d+) (?P<tag1>\S+)`},
+		HitCount: 1,
+		FindTime: config.Duration{Duration: time.Minute},
+		Actions: config.JailActions{
+			OnAdd: []string{"echo {{ .Tags }} > " + outFile},
+		},
+		ActionTimeout: config.Duration{Duration: 5 * time.Second},
+	}
+
+	jr, err := NewJailRuntime(cfg)
+	if err != nil {
+		t.Fatalf("NewJailRuntime: %v", err)
+	}
+
+	if err := jr.HandleEvent(context.Background(), watch.Event{
+		JailName: cfg.Name,
+		FilePath: "/var/log/apache2/site.example/access.log",
+		Line:     "Failed from 1.2.3.4 webapp",
+		Time:     time.Now(),
+	}); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	jr.WaitForInflight()
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "site.example,webapp" {
+		t.Errorf("Tags = %q, want %q", got, "site.example,webapp")
 	}
 }
 

--- a/internal/engine/jail_runtime.go
+++ b/internal/engine/jail_runtime.go
@@ -171,6 +171,18 @@ func (jr *JailRuntime) lifecycleCtx() action.Context {
 	}
 }
 
+// resolveLabel returns the label value for a match event according to the
+// jail's label_from config:
+//
+//	"parent_dir" – base name of the directory that contains filePath
+//	"match" or "" – text from the (?P<label>...) filter capture group
+func resolveLabel(labelFrom, matchLabel, filePath string) string {
+	if labelFrom == "parent_dir" {
+		return filepath.Base(filepath.Dir(filePath))
+	}
+	return matchLabel
+}
+
 // Reconfigure updates the jail's config and recompiles its filters.
 // It is safe to call concurrently with HandleEvent; the hit tracker is reset
 // because find_time and hit_count may have changed.
@@ -466,6 +478,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			Jail:      cfg.Name,
 			File:      evt.FilePath,
 			Line:      evt.Line,
+			Label:     resolveLabel(cfg.LabelFrom, result.Label, evt.FilePath),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		}
 		submitted := jr.runner.Submit(result.IP, func() {
@@ -489,6 +502,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			Jail:      cfg.Name,
 			File:      evt.FilePath,
 			Line:      evt.Line,
+			Label:     resolveLabel(cfg.LabelFrom, result.Label, evt.FilePath),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		}
 		if _, err := action.RunAllCompiled(ctx, onRemoveTmpls, actCtx, cfg.ActionTimeout.Duration); err != nil {
@@ -522,10 +536,11 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			return nil
 		}
 
+		label := resolveLabel(cfg.LabelFrom, result.Label, evt.FilePath)
 		slog.Info("JAIL on_add",
 			"jail", cfg.Name,
 			"ip", result.IP,
-			"label", result.Label,
+			"label", label,
 			"count", count,
 			"threshold", threshold,
 		)
@@ -544,6 +559,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			Jail:      cfg.Name,
 			File:      evt.FilePath,
 			Line:      evt.Line,
+			Label:     label,
 			JailTime:  int64(cfg.JailTime.Duration.Seconds()),
 			FindTime:  int64(findTime.Seconds()),
 			HitCount:  count,

--- a/internal/engine/jail_runtime.go
+++ b/internal/engine/jail_runtime.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"text/template"
 	"time"
@@ -171,16 +172,28 @@ func (jr *JailRuntime) lifecycleCtx() action.Context {
 	}
 }
 
-// resolveLabel returns the label value for a match event according to the
-// jail's label_from config:
+// resolveTags builds the list of tag values for a match event according to
+// the jail's tags_from config. Each entry in tagsFrom produces one element:
 //
-//	"parent_dir" – base name of the directory that contains filePath
-//	"match" or "" – text from the (?P<label>...) filter capture group
-func resolveLabel(labelFrom, matchLabel, filePath string) string {
-	if labelFrom == "parent_dir" {
-		return filepath.Base(filepath.Dir(filePath))
+//	"parent_dir"              – base name of the directory containing filePath
+//	"match_tag1"…"match_tag9" – text from the (?P<tag1>…)…(?P<tag9>…) capture group
+//
+// Entries whose source yields an empty string are omitted.
+func resolveTags(tagsFrom []string, namedGroups map[string]string, filePath string) []string {
+	tags := make([]string, 0, len(tagsFrom))
+	for _, src := range tagsFrom {
+		var v string
+		if src == "parent_dir" {
+			v = filepath.Base(filepath.Dir(filePath))
+		} else if len(src) == len("match_tag1") && src[:9] == "match_tag" {
+			groupName := src[len("match_"):] // "tag1"…"tag9"
+			v = namedGroups[groupName]
+		}
+		if v != "" {
+			tags = append(tags, v)
+		}
 	}
-	return matchLabel
+	return tags
 }
 
 // Reconfigure updates the jail's config and recompiles its filters.
@@ -478,7 +491,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			Jail:      cfg.Name,
 			File:      evt.FilePath,
 			Line:      evt.Line,
-			Label:     resolveLabel(cfg.LabelFrom, result.Label, evt.FilePath),
+			Tags:      strings.Join(resolveTags(cfg.TagsFrom, result.NamedGroups, evt.FilePath), ","),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		}
 		submitted := jr.runner.Submit(result.IP, func() {
@@ -502,7 +515,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			Jail:      cfg.Name,
 			File:      evt.FilePath,
 			Line:      evt.Line,
-			Label:     resolveLabel(cfg.LabelFrom, result.Label, evt.FilePath),
+			Tags:      strings.Join(resolveTags(cfg.TagsFrom, result.NamedGroups, evt.FilePath), ","),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		}
 		if _, err := action.RunAllCompiled(ctx, onRemoveTmpls, actCtx, cfg.ActionTimeout.Duration); err != nil {
@@ -536,11 +549,11 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			return nil
 		}
 
-		label := resolveLabel(cfg.LabelFrom, result.Label, evt.FilePath)
+		tags := resolveTags(cfg.TagsFrom, result.NamedGroups, evt.FilePath)
 		slog.Info("JAIL on_add",
 			"jail", cfg.Name,
 			"ip", result.IP,
-			"label", label,
+			"tags", strings.Join(tags, ","),
 			"count", count,
 			"threshold", threshold,
 		)
@@ -559,7 +572,7 @@ func (jr *JailRuntime) HandleEvent(ctx context.Context, evt watch.Event) error {
 			Jail:      cfg.Name,
 			File:      evt.FilePath,
 			Line:      evt.Line,
-			Label:     label,
+			Tags:      strings.Join(tags, ","),
 			JailTime:  int64(cfg.JailTime.Duration.Seconds()),
 			FindTime:  int64(findTime.Seconds()),
 			HitCount:  count,

--- a/internal/filter/extract.go
+++ b/internal/filter/extract.go
@@ -25,17 +25,20 @@ func Extract(re *regexp.Regexp, line string) string {
 	return ""
 }
 
-// ExtractLabel attempts to get the "label" named capture group from a regex match on line.
-// Returns "" if no named "label" group exists or it didn't match.
-func ExtractLabel(re *regexp.Regexp, line string) string {
+// ExtractNamedGroups returns a map of all named capture groups (excluding "ip")
+// that matched in line. Groups that are present in the pattern but did not
+// participate in the match are included with an empty string value.
+// Returns nil when the pattern does not match line at all.
+func ExtractNamedGroups(re *regexp.Regexp, line string) map[string]string {
 	match := re.FindStringSubmatch(line)
 	if match == nil {
-		return ""
+		return nil
 	}
+	groups := make(map[string]string)
 	for i, name := range re.SubexpNames() {
-		if name == "label" && i < len(match) {
-			return match[i]
+		if name != "" && name != "ip" && i < len(match) {
+			groups[name] = match[i]
 		}
 	}
-	return ""
+	return groups
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -102,6 +102,44 @@ func TestExtractFallback(t *testing.T) {
 	}
 }
 
+func TestExtractNamedGroups(t *testing.T) {
+	cf, _ := Compile(`(?P<ip>\d+\.\d+\.\d+\.\d+) (?P<tag1>\S+) (?P<tag2>\S+)`)
+	line := "1.2.3.4 webapp prod"
+	got := ExtractNamedGroups(cf.re, line)
+	if got["tag1"] != "webapp" {
+		t.Errorf("tag1 = %q, want %q", got["tag1"], "webapp")
+	}
+	if got["tag2"] != "prod" {
+		t.Errorf("tag2 = %q, want %q", got["tag2"], "prod")
+	}
+	// "ip" group must be excluded.
+	if _, ok := got["ip"]; ok {
+		t.Error("NamedGroups should not include the \"ip\" group")
+	}
+}
+
+func TestExtractNamedGroupsNoMatch(t *testing.T) {
+	cf, _ := Compile(`(?P<ip>\d+\.\d+\.\d+\.\d+)`)
+	got := ExtractNamedGroups(cf.re, "no ip here")
+	if got != nil {
+		t.Errorf("expected nil for non-matching line, got %v", got)
+	}
+}
+
+func TestMatchPopulatesNamedGroups(t *testing.T) {
+	inc, _ := CompileAll([]string{`(?P<ip>\d+\.\d+\.\d+\.\d+) (?P<tag1>\S+)`})
+	res, err := Match("1.2.3.4 webapp", inc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected Result, got nil")
+	}
+	if res.NamedGroups["tag1"] != "webapp" {
+		t.Errorf("NamedGroups[tag1] = %q, want %q", res.NamedGroups["tag1"], "webapp")
+	}
+}
+
 // --- ValidateNetType tests ---
 
 func TestValidateNetTypeIP(t *testing.T) {

--- a/internal/filter/match.go
+++ b/internal/filter/match.go
@@ -2,10 +2,10 @@ package filter
 
 // Result is returned from a successful match.
 type Result struct {
-	IP      string // extracted IP or CIDR text
-	Label   string // extracted label text (from (?P<label>...) group), may be empty
-	Line    string // original log line
-	Pattern string // matched filter pattern
+	IP          string            // extracted IP or CIDR text
+	NamedGroups map[string]string // all named capture groups from the match (excluding "ip")
+	Line        string            // original log line
+	Pattern     string            // matched filter pattern
 }
 
 // Match applies include-first + optional exclude semantics:
@@ -13,7 +13,7 @@ type Result struct {
 //  2. If no include filter matches, return nil, nil (line ignored).
 //  3. Try each excludeFilter; if any matches, return nil, nil (suppressed).
 //  4. Extract the named capture group "ip" from the include match.
-//  5. Return a Result with IP, Line, Pattern.
+//  5. Return a Result with IP, NamedGroups, Line, Pattern.
 func Match(line string, includes, excludes []*CompiledFilter) (*Result, error) {
 	// Step 1 & 2: find first matching include filter.
 	var matched *CompiledFilter
@@ -34,15 +34,15 @@ func Match(line string, includes, excludes []*CompiledFilter) (*Result, error) {
 		}
 	}
 
-	// Step 4: extract IP from named (or first) capture group.
+	// Step 4: extract IP and all other named groups.
 	ip := Extract(matched.re, line)
-	label := ExtractLabel(matched.re, line)
+	namedGroups := ExtractNamedGroups(matched.re, line)
 
 	// Step 5: return result.
 	return &Result{
-		IP:      ip,
-		Label:   label,
-		Line:    line,
-		Pattern: matched.pattern,
+		IP:          ip,
+		NamedGroups: namedGroups,
+		Line:        line,
+		Pattern:     matched.pattern,
 	}, nil
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -106,3 +106,4 @@ All action command strings are Go `text/template` strings. Available variables:
 | `{{ .File }}` | Source log file |
 | `{{ .Line }}` | Matching log line |
 | `{{ .Timestamp }}` | RFC3339 timestamp of the match event |
+| `{{ .Tags }}` | Comma-joined tag values from `tags_from` (empty string when no tags configured) |


### PR DESCRIPTION
## Summary

Resolves #35.

Adds a `tags_from` config option to jails and whitelists. It is an ordered array of tag sources whose resolved values are joined as a comma-separated string, exposed as `{{.Tags}}` in action templates and written to the `tags` structured log field on every match event.

### Tag sources

| Source | Produces |
|---|---|
| `parent_dir` | Base name of the directory containing the matched file |
| `match_tag1`...`match_tag9` | Text from named capture groups `(?P<tag1>...)`...`(?P<tag9>...)` in the filter |

`tags_from` defaults to `[]` (empty — no tags). Multiple sources are combined in declaration order.

### Motivation

For Apache/nginx virtual-host setups the access log is at a path like `/var/log/apache2/some-domain.com/access.log`. The domain name is not in the log lines themselves. Setting `tags_from: [parent_dir]` makes `{{.Tags}}` resolve to `some-domain.com` automatically.

When a filter also captures a service identifier, both can be combined:

```yaml
tags_from: [parent_dir, match_tag1]
# file: /var/log/apache2/site.example/access.log  +  filter captures (?P<tag1>webapp)
# Tags = "site.example,webapp"
```

### Example config

```yaml
jails:
  - name: apache-vhosts
    files:
      - /var/log/apache2/*/access.log
    tags_from: [parent_dir]
    filters:
      - 'Failed password .* from (?P<ip>[0-9.]+)'
    actions:
      on_add:
        - 'nft add element inet filter blacklist { {{ .IP }} } comment "{{ .Tags }}"'
```

### Changes

| Layer | What changed |
|---|---|
| `internal/filter` | `Result.Label` replaced by `Result.NamedGroups map[string]string`; `ExtractLabel` replaced by `ExtractNamedGroups` |
| `internal/action` | `Context.Label string` replaced by `Context.Tags string` (comma-joined) |
| `internal/config` | `LabelFrom string` replaced by `TagsFrom []string`; validation rejects unknown sources and `match_tag0` / `match_tag10+` |
| `internal/engine` | `resolveLabel` replaced by `resolveTags(tagsFrom, namedGroups, filePath)`; all context builds and slog updated |
| docs | `docs/jailtimed.md` and `samples/README.md` updated |
| tests | filter, action, config, and engine layers all updated and extended |