### PR TITLE
fix: support partial names in exclude_files via substring matching

### DIFF
--- a/internal/watch/fsnotify.go
+++ b/internal/watch/fsnotify.go
@@ -157,7 +157,6 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 
 	initialScan := func() {
 		currentSpecs := b.getSpecs()
-		excluded := buildExcludeSet(currentSpecs)
 
 		newPathToJails := make(map[string][]string)
 		newStaticPathToJails := make(map[string][]string)
@@ -170,7 +169,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 					paths = []string{}
 				}
 				for _, p := range paths {
-					if _, ex := excluded[p]; ex {
+					if isExcluded(p, currentSpecs) {
 						continue
 					}
 					if spec.WatchMode == "static" {
@@ -200,8 +199,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 
 	handleCreate := func(name string) {
 		currentSpecs := b.getSpecs()
-		excluded := buildExcludeSet(currentSpecs)
-		if _, ex := excluded[name]; ex {
+		if isExcluded(name, currentSpecs) {
 			return
 		}
 
@@ -260,7 +258,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 					continue
 				}
 				for _, p := range paths {
-					if _, ex := excluded[p]; ex {
+					if isExcluded(p, currentSpecs) {
 						continue
 					}
 					// Determine mode for this pattern.

--- a/internal/watch/poll.go
+++ b/internal/watch/poll.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -60,22 +61,23 @@ type staticPathInfo struct {
 	jails []string
 }
 
-// buildExcludeSet expands all ExcludeGlobs patterns from specs and returns
-// a set of paths to exclude.
-func buildExcludeSet(specs []WatchSpec) map[string]struct{} {
-	excluded := make(map[string]struct{})
+// isExcluded reports whether path should be excluded based on the ExcludeGlobs
+// patterns in any of the specs. Each pattern is matched in two ways:
+//  1. As a filepath.Match glob against the full path (e.g. "/var/log/*/access.log").
+//  2. As a substring of the path, allowing partial names (e.g. "kitchendraw.co.nz"
+//     will exclude "/var/log/apache2/kitchendraw.co.nz/access.log").
+func isExcluded(path string, specs []WatchSpec) bool {
 	for _, spec := range specs {
 		for _, pattern := range spec.ExcludeGlobs {
-			paths, err := filepath.Glob(pattern)
-			if err != nil {
-				continue
+			if matched, err := filepath.Match(pattern, path); err == nil && matched {
+				return true
 			}
-			for _, p := range paths {
-				excluded[p] = struct{}{}
+			if strings.Contains(path, pattern) {
+				return true
 			}
 		}
 	}
-	return excluded
+	return false
 }
 
 // Start begins polling. Every interval it expands globs across all WatchSpecs,
@@ -105,8 +107,6 @@ func (b *PollBackend) Start(ctx context.Context, specs []WatchSpec, drain DrainF
 			}
 			currentSpecs := b.getSpecs()
 
-			excluded := buildExcludeSet(currentSpecs)
-
 			tailPaths := make(map[string]*tailPathInfo)
 			staticPaths := make(map[string]*staticPathInfo)
 
@@ -117,7 +117,7 @@ func (b *PollBackend) Start(ctx context.Context, specs []WatchSpec, drain DrainF
 						continue
 					}
 					for _, p := range paths {
-						if _, ex := excluded[p]; ex {
+						if isExcluded(p, currentSpecs) {
 							continue
 						}
 						if spec.WatchMode == "static" {

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -974,6 +974,70 @@ func TestPollBackendExcludeGlobs(t *testing.T) {
 	}
 }
 
+// TestPollBackendExcludeGlobsPartialName verifies that exclude_files entries
+// that are partial path components (e.g. "kitchendraw.co.nz") correctly
+// exclude files whose full path contains that substring, such as
+// /var/log/apache2/kitchendraw.co.nz/access.log.
+func TestPollBackendExcludeGlobsPartialName(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create subdirectory structure mirroring /var/log/apache2/<vhost>/access.log
+	excludedDir := filepath.Join(dir, "kitchendraw.co.nz")
+	includedDir := filepath.Join(dir, "example.com")
+	if err := os.MkdirAll(excludedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(includedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	excludedFile := filepath.Join(excludedDir, "access.log")
+	includedFile := filepath.Join(includedDir, "access.log")
+
+	if err := os.WriteFile(excludedFile, []byte("excluded-line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(includedFile, []byte("included-line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	spec := WatchSpec{
+		JailName:     "test",
+		Globs:        []string{filepath.Join(dir, "*/access.log")},
+		ExcludeGlobs: []string{"kitchendraw.co.nz"}, // partial name only
+		WatchMode:    "tail",
+		ReadFromEnd:  false,
+	}
+
+	drain, wait := drainToSliceN(1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	b := NewPollBackend(50 * time.Millisecond)
+	go b.Start(ctx, []WatchSpec{spec}, drain)
+	time.Sleep(150 * time.Millisecond)
+
+	lines := wait()
+	cancel()
+
+	for _, l := range lines {
+		if l.FilePath == excludedFile {
+			t.Errorf("excluded file appeared in drain: %s", l.FilePath)
+		}
+		if l.Line == "excluded-line" {
+			t.Errorf("excluded line appeared in drain: %s", l.Line)
+		}
+	}
+	found := false
+	for _, l := range lines {
+		if l.Line == "included-line" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("included file line not found in drain")
+	}
+}
+
 func TestPollBackendStaticMode(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "whitelist.txt")


### PR DESCRIPTION
## Problem

`exclude_files` entries like `kitchendraw.co.nz` were not working as partial path matches. The previous implementation used `filepath.Glob(pattern)` which only finds files with that exact name — it would never match `/var/log/apache2/kitchendraw.co.nz/access.log`.

**Example config that was broken:**
```yaml
files:
  - /var/log/apache2/*/access.log
exclude_files:
  - kitchendraw.co.nz
  - nationwiderv.co.nz
  - bcibus.co.nz
```

## Fix

Replaced `buildExcludeSet` (glob-expansion to exact-path map) with `isExcluded(path, specs)` in both `poll.go` and `fsnotify.go`. Each candidate path is checked two ways:

1. `filepath.Match(pattern, path)` — full glob patterns continue to work as before
2. `strings.Contains(path, pattern)` — partial names/path components now also match

## Test

Added `TestPollBackendExcludeGlobsPartialName` which creates a directory structure mirroring the real-world case:
```
<tempdir>/kitchendraw.co.nz/access.log  ← should be excluded
<tempdir>/example.com/access.log         ← should be included
```
With `ExcludeGlobs: []string{"kitchendraw.co.nz"}`, the test asserts that the excluded file's lines never appear in drain and the included file's lines do.