### PR TITLE
ci: add GitHub Actions for CI and automated release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build binaries
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          LDFLAGS="-X github.com/sgw/jailtime/pkg/version.Version=${VERSION}"
+          go build -ldflags "$LDFLAGS" ./cmd/jailtimed
+          go build -ldflags "$LDFLAGS" ./cmd/jailtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Version bump & tag
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Use a PAT so the pushed commit/tag can trigger downstream workflows
+          # if needed. Falls back to GITHUB_TOKEN (sufficient for tag creation).
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version bump from PR labels
+        id: bump
+        run: |
+          LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
+          if echo "$LABELS" | grep -qi "semver:major"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$LABELS" | grep -qi "semver:minor"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute next version
+        id: version
+        run: |
+          CURRENT=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$CURRENT" ]; then
+            CURRENT="v0.0.0"
+          fi
+          BARE="${CURRENT#v}"
+          MAJOR=$(echo "$BARE" | cut -d. -f1)
+          MINOR=$(echo "$BARE" | cut -d. -f2)
+          PATCH=$(echo "$BARE" | cut -d. -f3)
+
+          case "${{ steps.bump.outputs.type }}" in
+            major) MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR+1)); PATCH=0 ;;
+            *)     PATCH=$((PATCH+1)) ;;
+          esac
+
+          NEXT="${MAJOR}.${MINOR}.${PATCH}"
+          echo "bare=${NEXT}"   >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEXT}"   >> "$GITHUB_OUTPUT"
+
+      - name: Update version file
+        run: |
+          printf 'package version\n\n// Version is set at build time via -ldflags "-X github.com/sgw/jailtime/pkg/version.Version=<tag>".\n// It defaults to "dev" when not set.\nvar Version = "%s"\n\nconst AppName = "jailtime"\n' \
+            "${{ steps.version.outputs.bare }}" > pkg/version/version.go
+
+      - name: Commit version bump
+        run: |
+          git add pkg/version/version.go
+          git commit -m "chore: bump version to ${{ steps.version.outputs.tag }} [skip ci]"
+
+      - name: Create and push tag
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin main
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,7 @@
 package version
 
-const Version = "0.1.0"
+// Version is set at build time via -ldflags "-X github.com/sgw/jailtime/pkg/version.Version=<tag>".
+// It defaults to "dev" when not set.
+var Version = "dev"
+
 const AppName = "jailtime"


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows and updates the version package.

### `ci.yml` — Tests on push/PR
- Triggers on any push to non-`main` branches and on PRs targeting `main`
- Runs `go test ./...`
- Builds both binaries (`jailtimed`, `jailtime`) with version injected via `-ldflags` from `git describe --tags`

### `release.yml` — Auto version bump & tag on merge
- Triggers when a PR is merged to `main`
- Determines version bump type from PR labels:
  - `semver:major` → major bump
  - `semver:minor` → minor bump
  - _(default)_ → patch bump
- Updates `pkg/version/version.go` with the new version
- Commits the change and pushes a `vX.Y.Z` tag

### `pkg/version/version.go`
- Changed `Version` from `const` to `var` so `-ldflags` can override it at build time, keeping the reported version consistent with the git tag
- Defaults to `"dev"` when built without ldflags (e.g. `go run`)