### PR TITLE
fix(ci): checkout main ref in release workflow to avoid non-fast-forward push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
-          # Use a PAT so the pushed commit/tag can trigger downstream workflows
-          # if needed. Falls back to GITHUB_TOKEN (sufficient for tag creation).
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure git


### PR DESCRIPTION
## Problem

The release workflow checked out the PR's head SHA (the feature branch tip). By the time the workflow ran post-merge, `origin/main` already contained the merge commit — making the version-bump `git push origin main` non-fast-forward.

## Fix

Add `ref: main` to the `actions/checkout` step so the workflow always starts from the post-merge state of `main`.