### PR TITLE
Fix fsnotify glob rollover detection

### DIFF
--- a/internal/watch/fsnotify.go
+++ b/internal/watch/fsnotify.go
@@ -71,10 +71,20 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 	dirty := make(map[string]struct{})       // tail-mode dirty paths
 	staticDirty := make(map[string]struct{}) // static-mode dirty paths
 	parentDirs := make(map[string][]string)  // parent dir → []glob patterns
+	watchedDirs := make(map[string]struct{}) // directories watched for creates
 
 	var drainTimerC <-chan time.Time // nil = idle
 	var lastDrainTime time.Duration  // previous drain wall time
 	var pendingTriggerAt time.Time   // when the current pending drain was first triggered
+
+	ensureDirWatch := func(dir string) {
+		if _, ok := watchedDirs[dir]; ok {
+			return
+		}
+		if err := watcher.Add(dir); err == nil {
+			watchedDirs[dir] = struct{}{}
+		}
+	}
 
 	readTailLines := func(p string) []RawLine {
 		ft, ok := tailers[p]
@@ -130,10 +140,12 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 		}
 		tailers[p] = ft
 		dirty[p] = struct{}{}
+		ensureDirWatch(filepath.Dir(p))
 		_ = watcher.Add(p)
 	}
 
 	openStatic := func(p string) {
+		ensureDirWatch(filepath.Dir(p))
 		if _, ok := staticPathToJails[p]; ok {
 			// Already tracked; mark dirty to do initial diff.
 			staticDirty[p] = struct{}{}
@@ -184,7 +196,7 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 				// Watch parent dir for CREATE events.
 				pd := globParentDir(pattern)
 				parentDirs[pd] = appendUniq(parentDirs[pd], pattern)
-				_ = watcher.Add(pd)
+				ensureDirWatch(pd)
 			}
 		}
 		for p := range newPathToJails {
@@ -222,6 +234,8 @@ func (b *FsnotifyBackend) Start(ctx context.Context, specs []WatchSpec, drain Dr
 
 		// Case 1: known tail file recreated (rotation).
 		if ft, ok := tailers[name]; ok {
+			ensureDirWatch(filepath.Dir(name))
+			_ = watcher.Add(name)
 			_ = ft.Reopen(false)
 			dirty[name] = struct{}{}
 			return

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -403,6 +403,65 @@ func TestFsnotifyBackendSubdirGlob(t *testing.T) {
 	}
 }
 
+// TestFsnotifyBackendSubdirGlobRotation verifies that an already-matched file in
+// an existing wildcard subdirectory is rediscovered after log rotation
+// (rename + recreate) and continues to emit events from the recreated file.
+func TestFsnotifyBackendSubdirGlobRotation(t *testing.T) {
+	base := t.TempDir()
+	subdir := filepath.Join(base, "site1")
+	if err := os.Mkdir(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(subdir, "access.log")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	pattern := filepath.Join(base, "*", "access.log")
+	b := NewFsnotifyBackend(100 * time.Millisecond)
+	specs := []WatchSpec{{JailName: "apache", Globs: []string{pattern}, ReadFromEnd: false}}
+	out, cancel := startBackendDrain(t, b, specs)
+	defer cancel()
+
+	time.Sleep(150 * time.Millisecond)
+	drainTimeout := time.After(300 * time.Millisecond)
+drainLoop:
+	for {
+		select {
+		case <-out:
+		case <-drainTimeout:
+			break drainLoop
+		}
+	}
+
+	if err := os.Rename(path, path+".1"); err != nil {
+		t.Fatal(err)
+	}
+	newF, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(150 * time.Millisecond)
+	fmt.Fprintln(newF, "9.8.7.6 GET /rotated 200")
+	newF.Close()
+
+	ev, ok := waitEvent(out, 2*time.Second)
+	if !ok {
+		t.Fatal("timed out waiting for event after glob-backed rotation")
+	}
+	if ev.Line != "9.8.7.6 GET /rotated 200" {
+		t.Errorf("expected line %q, got %q", "9.8.7.6 GET /rotated 200", ev.Line)
+	}
+	if ev.FilePath != path {
+		t.Errorf("expected FilePath %q, got %q", path, ev.FilePath)
+	}
+	if !containsJail(ev.Jails, "apache") {
+		t.Errorf("expected Jails to contain %q, got %v", "apache", ev.Jails)
+	}
+}
+
 // TestFsnotifyBackendBasic mirrors TestPollBackendBasic but uses fsnotify backend.
 func TestFsnotifyBackendBasic(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- keep fsnotify watches on matched file parent directories so recreated glob-backed log files emit create events
- reattach the file watch when a known tailed path is recreated after rotation
- add a regression test for */access.log rollover in an existing matched subdirectory