### PR TITLE
feat(version): add --version flag to jailtime CLI

### DIFF
--- a/cmd/jailtime/main.go
+++ b/cmd/jailtime/main.go
@@ -105,9 +105,12 @@ any included fragment files under jails.d/.`,
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s %s\n", version.AppName, version.Version)
+			fmt.Printf("%s v%s\n", version.AppName, version.Version)
 		},
 	}
+
+	root.Version = version.Version
+	root.SetVersionTemplate(fmt.Sprintf("%s v%s\n", version.AppName, version.Version))
 
 	// ── config ───────────────────────────────────────────────────────────────
 	configCmd := &cobra.Command{

--- a/cmd/jailtimed/main.go
+++ b/cmd/jailtimed/main.go
@@ -35,7 +35,7 @@ func main() {
 	root.Flags().Bool("version", false, "print version and exit")
 	root.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if v, _ := cmd.Flags().GetBool("version"); v {
-			fmt.Printf("%s %s\n", version.AppName, version.Version)
+			fmt.Printf("%s v%s\n", version.AppName, version.Version)
 			os.Exit(0)
 		}
 		return nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,4 +4,4 @@ package version
 // It defaults to "dev" when not set.
 var Version = "1.0.3"
 
-const AppName = "jailtime"
+const AppName = "Jailtime"


### PR DESCRIPTION
## Summary

- Adds `jailtime --version` flag via cobra's built-in `Version` field + `SetVersionTemplate`
- Capitalises `AppName` to `"Jailtime"` in `pkg/version`
- Prefixes the version number with `v` so output is `Jailtime v1.0.3`
- Both `jailtime --version` and `jailtime version` now produce the same format
- `jailtimed --version` updated to match

Closes #44

## Test plan

- [ ] `jailtime --version` outputs `Jailtime v1.0.3`
- [ ] `jailtime version` outputs `Jailtime v1.0.3`
- [ ] `jailtimed --version` outputs `Jailtime v1.0.3`
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)