### PR TITLE
Fix jailtimed writable paths under ProtectSystem=strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ sudo systemctl status jailtimed
 journalctl -u jailtimed -f
 ```
 
+The packaged unit keeps the filesystem mostly read-only and grants write access
+only to `/var/cache/whois_cache` and `/var/log/intrusion` for the bundled
+whois/RDAP cache and intrusion-log actions.
+
 ### Verify
 
 ```sh

--- a/deploy/jailtimed.service
+++ b/deploy/jailtimed.service
@@ -9,6 +9,10 @@ Restart=on-failure
 RestartSec=2s
 RuntimeDirectory=jailtime
 RuntimeDirectoryMode=0755
+CacheDirectory=whois_cache
+CacheDirectoryMode=0755
+LogsDirectory=intrusion
+LogsDirectoryMode=0755
 
 # Hardening (tune for firewall backend needs)
 NoNewPrivileges=true

--- a/deploy/jailtimed_service_test.go
+++ b/deploy/jailtimed_service_test.go
@@ -1,0 +1,30 @@
+package deploy_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJailtimedServiceAllowsRequiredWritableDirectories(t *testing.T) {
+	servicePath := filepath.Join("jailtimed.service")
+
+	data, err := os.ReadFile(servicePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", servicePath, err)
+	}
+
+	content := string(data)
+	requiredDirectives := []string{
+		"ProtectSystem=strict",
+		"CacheDirectory=whois_cache",
+		"LogsDirectory=intrusion",
+	}
+
+	for _, directive := range requiredDirectives {
+		if !strings.Contains(content, directive) {
+			t.Fatalf("service file missing %q", directive)
+		}
+	}
+}

--- a/docs/jailtimed.md
+++ b/docs/jailtimed.md
@@ -433,6 +433,9 @@ journalctl -u jailtimed -f
 ```
 
 The unit file runs jailtimed as root (required for iptables/nft/ipset operations).
+It keeps `ProtectSystem=strict` enabled while allowing writes only to the
+systemd-managed directories `/var/cache/whois_cache` and `/var/log/intrusion`,
+which are used by the bundled RDAP/cache tooling and intrusion log actions.
 Adjust `deploy/jailtimed.service` if you use a capability-based setup instead.
 
 ---


### PR DESCRIPTION
## Summary
- keep ProtectSystem=strict while making /var/cache/whois_cache and /var/log/intrusion writable via CacheDirectory and LogsDirectory
- add a regression test that locks the required unit directives into the repo
- document the writable paths in the README and systemd docs

## Problem
Production writes were failing because the unit mounted the filesystem read-only for the service, which blocked both the RDAP cache used by iptocidr and the intrusion log append used by the CIDR logging pipeline.

## Validation
- go test ./...
- go build ./cmd/jailtimed
- go build ./cmd/jailtime
